### PR TITLE
Add in-text footnotes for AI-identified entities (characters, locations, historical figures, terms)

### DIFF
--- a/xray.koplugin/languages/en.po
+++ b/xray.koplugin/languages/en.po
@@ -215,14 +215,41 @@ msgstr "Very Detailed"
 msgid "dont_ask_again"
 msgstr "Don't ask again"
 
+msgid "entity_cat_characters"
+msgstr "Characters"
+
+msgid "entity_cat_historical_figures"
+msgstr "Historical Figures"
+
+msgid "entity_cat_locations"
+msgstr "Locations"
+
+msgid "entity_cat_terms"
+msgstr "Terms"
+
+msgid "entity_footnotes_enabled"
+msgstr "Enable Entity Footnotes"
+
 msgid "entity_label_characters"
 msgstr "characters"
 
 msgid "entity_label_locations"
 msgstr "locations"
 
+msgid "entity_manual_scan_button"
+msgstr "Scan/Rescan"
+
+msgid "entity_no_description"
+msgstr "No description available yet."
+
 msgid "entity_not_found"
 msgstr "'%s' was not found as a character or location."
+
+msgid "entity_scanning_book"
+msgstr "Scanning book for footnotes..."
+
+msgid "entity_style_settings"
+msgstr "Style & Underline Settings"
 
 msgid "entity_ui_style_both"
 msgstr "Modern Popup (Both)"
@@ -490,6 +517,12 @@ msgstr "Display & UI Settings"
 
 msgid "menu_enter_custom_model"
 msgstr "Enter custom model..."
+
+msgid "menu_entity_categories"
+msgstr "Entity Categories"
+
+msgid "menu_entity_footnotes"
+msgstr "Entity Footnotes"
 
 msgid "menu_entity_ui_mode"
 msgstr "Entity Description Style"

--- a/xray.koplugin/languages/en.po
+++ b/xray.koplugin/languages/en.po
@@ -248,6 +248,9 @@ msgstr "'%s' was not found as a character or location."
 msgid "entity_scanning_book"
 msgstr "Scanning book for footnotes..."
 
+msgid "entity_scanning_title"
+msgstr "X-Ray: Entity Footnotes"
+
 msgid "entity_style_settings"
 msgstr "Style & Underline Settings"
 

--- a/xray.koplugin/main.lua
+++ b/xray.koplugin/main.lua
@@ -48,6 +48,7 @@ safeRequireMixin("xray_ui")
 safeRequireMixin("xray_fetch")
 safeRequireMixin("xray_mentions")
 safeRequireMixin("xray_unitscanner")
+safeRequireMixin("xray_entityscanner")
 
 
 function XRayPlugin:init()
@@ -320,7 +321,7 @@ function XRayPlugin:onReaderReady()
         if self.destroyed then return end
         if self.mountUnderlineOverlay then self:mountUnderlineOverlay() end
         if self.mountTapHandler then self:mountTapHandler() end
-        
+
 
         local settings = self.ai_helper and self.ai_helper.settings or {}
         if settings.unit_new_feature_prompt_seen ~= true then
@@ -336,6 +337,12 @@ function XRayPlugin:onReaderReady()
                     end
                 end
             end
+        end
+
+        if self.mountEntityUnderlineOverlay then self:mountEntityUnderlineOverlay() end
+        if self.mountEntityTapHandler then self:mountEntityTapHandler() end
+        if self.scanBookForEntities and settings.entity_footnotes_enabled ~= false then
+            self:scanBookForEntities()
         end
     end)
 
@@ -1084,6 +1091,90 @@ function XRayPlugin:getSubMenuItems()
                                     if self.scanBookForUnits then self:scanBookForUnits() end
                                 end
                             }
+                        }
+                    }
+                },
+                separator = true,
+            },
+            {
+                is_entity_footnotes = true,
+                text = self.loc:t("menu_entity_footnotes") or "Entity Footnotes",
+                keep_menu_open = true,
+                sub_item_table = {
+                    {
+                        text = self.loc:t("entity_footnotes_enabled") or "Enable Entity Footnotes",
+                        checked_func = function()
+                            return self.ai_helper.settings.entity_footnotes_enabled ~= false
+                        end,
+                        callback = function()
+                            local current = self.ai_helper.settings.entity_footnotes_enabled ~= false
+                            self.ai_helper:saveSettings({ entity_footnotes_enabled = not current })
+                            if self.scanBookForEntities then self:scanBookForEntities() end
+                        end
+                    },
+                    {
+                        text = self.loc:t("entity_manual_scan_button") or "Scan/Rescan",
+                        keep_menu_open = true,
+                        callback = function()
+                            if self.scanBookForEntities then self:scanBookForEntities(true) end
+                        end,
+                        separator = true,
+                    },
+                    {
+                        text = self.loc:t("entity_style_settings") or "Style & Underline Settings",
+                        keep_menu_open = true,
+                        callback = function()
+                            self:showUnitStyleCard()
+                        end
+                    },
+                    {
+                        text = self.loc:t("menu_entity_categories") or "Entity Categories",
+                        keep_menu_open = true,
+                        sub_item_table = {
+                            {
+                                text = self.loc:t("entity_cat_characters") or "Characters",
+                                checked_func = function()
+                                    return self.ai_helper.settings.entity_cat_characters ~= false
+                                end,
+                                callback = function()
+                                    local curr = self.ai_helper.settings.entity_cat_characters ~= false
+                                    self.ai_helper:saveSettings({ entity_cat_characters = not curr })
+                                    if self.scanBookForEntities then self:scanBookForEntities(true) end
+                                end
+                            },
+                            {
+                                text = self.loc:t("entity_cat_historical_figures") or "Historical Figures",
+                                checked_func = function()
+                                    return self.ai_helper.settings.entity_cat_historical_figures ~= false
+                                end,
+                                callback = function()
+                                    local curr = self.ai_helper.settings.entity_cat_historical_figures ~= false
+                                    self.ai_helper:saveSettings({ entity_cat_historical_figures = not curr })
+                                    if self.scanBookForEntities then self:scanBookForEntities(true) end
+                                end
+                            },
+                            {
+                                text = self.loc:t("entity_cat_locations") or "Locations",
+                                checked_func = function()
+                                    return self.ai_helper.settings.entity_cat_locations ~= false
+                                end,
+                                callback = function()
+                                    local curr = self.ai_helper.settings.entity_cat_locations ~= false
+                                    self.ai_helper:saveSettings({ entity_cat_locations = not curr })
+                                    if self.scanBookForEntities then self:scanBookForEntities(true) end
+                                end
+                            },
+                            {
+                                text = self.loc:t("entity_cat_terms") or "Terms",
+                                checked_func = function()
+                                    return self.ai_helper.settings.entity_cat_terms ~= false
+                                end,
+                                callback = function()
+                                    local curr = self.ai_helper.settings.entity_cat_terms ~= false
+                                    self.ai_helper:saveSettings({ entity_cat_terms = not curr })
+                                    if self.scanBookForEntities then self:scanBookForEntities(true) end
+                                end
+                            },
                         }
                     }
                 },

--- a/xray.koplugin/xray_entityscanner.lua
+++ b/xray.koplugin/xray_entityscanner.lua
@@ -13,6 +13,7 @@ local FrameContainer = require("ui/widget/container/framecontainer")
 local VerticalGroup = require("ui/widget/verticalgroup")
 local VerticalSpan = require("ui/widget/verticalspan")
 local TextBoxWidget = require("ui/widget/textboxwidget")
+local ProgressBarDialog = require("ui/widget/progressbardialog")
 local Font = require("ui/font")
 local Geom = require("ui/geometry")
 local DocSettings = require("docsettings")
@@ -499,22 +500,64 @@ function M:scanBookForEntities(force)
     local doc = self.ui.document
 
     local Notification = require("ui/widget/notification")
-    UIManager:show(Notification:new{
-        text = self.loc:t("entity_scanning_book") or "Scanning book for footnotes...",
-        timeout = 2,
-        toast = true,
-    })
+    local AlphaContainer = require("ui/widget/container/alphacontainer")
+
+    -- Modal progress dialog (dismissable = false) instead of a passive toast: doc:findAllText
+    -- blocks the UI thread, and without a visible "busy" indicator the app can appear to have
+    -- frozen while it's actually still scanning.
+    local progress_msg = ProgressBarDialog:new{
+        title = self.loc:t("entity_scanning_title") or "X-Ray: Entity Footnotes",
+        subtitle = self.loc:t("entity_scanning_book") or "Scanning book for footnotes...",
+        progress_max = 100,
+        dismissable = false,
+        refresh_time_seconds = 0.05,
+    }
+
+    local sw, sh = Screen:getWidth(), Screen:getHeight()
+    local dim_child = {
+        getSize = function(this)
+            return Geom:new{ w = sw, h = sh }
+        end,
+        paintTo = function(this, bb, x, y)
+            bb:paintRoundedRect(x, y, sw, sh, Blitbuffer.COLOR_BLACK, 0)
+        end
+    }
+    local dim_bg = AlphaContainer:new{
+        alpha = 0.4,
+        dim_child
+    }
+
+    local orig_paintTo = progress_msg.paintTo
+    progress_msg.paintTo = function(this, bb, x, y)
+        dim_bg:paintTo(bb, 0, 0)
+        orig_paintTo(this, bb, x, y)
+    end
+
+    local orig_onCloseWidget = progress_msg.onCloseWidget
+    progress_msg.onCloseWidget = function(this)
+        dim_bg:onCloseWidget()
+        if orig_onCloseWidget then
+            orig_onCloseWidget(this)
+        end
+    end
+
+    progress_msg:show()
+    UIManager:forceRePaint()
 
     UIManager:scheduleIn(0.1, function()
         if self.destroyed then
             self._entity_scan_in_progress = false
+            progress_msg:close()
             return
         end
 
         local ok_scan, err_scan = pcall(function()
+            progress_msg:reportProgress(10)
+
             local patterns = _buildChunks(terms)
             local hits = {}
-            for _, pat in ipairs(patterns) do
+            local total_patterns = math.max(1, #patterns)
+            for i, pat in ipairs(patterns) do
                 local ok1, hits1 = pcall(function()
                     return doc:findAllText(pat, true, 0, 5000, true)
                 end)
@@ -523,7 +566,10 @@ function M:scanBookForEntities(force)
                 else
                     log("scanBookForEntities: findAllText pcall failed (non-fatal): " .. tostring(hits1))
                 end
+                progress_msg:reportProgress(10 + math.floor(70 * i / total_patterns))
             end
+
+            progress_msg:reportProgress(85)
 
             -- Deduplicate overlapping hits by end xpointer, keeping the longest match
             local unique_hits = {}
@@ -552,6 +598,7 @@ function M:scanBookForEntities(force)
             self.entity_xp_matches = xp_matches
             self._entity_box_cache_sig = nil
             log("scanBookForEntities: found " .. tostring(#xp_matches) .. " entity mentions")
+            progress_msg:reportProgress(95)
 
             UIManager:show(Notification:new{
                 text = tostring(#xp_matches) .. " footnotes found",
@@ -573,6 +620,9 @@ function M:scanBookForEntities(force)
         end)
 
         self._entity_scan_in_progress = false
+        progress_msg:reportProgress(100)
+        progress_msg:close()
+
         if not ok_scan then
             log("scanBookForEntities async error: " .. tostring(err_scan))
         end

--- a/xray.koplugin/xray_entityscanner.lua
+++ b/xray.koplugin/xray_entityscanner.lua
@@ -199,12 +199,16 @@ function M:_resolveEntityHighlightBoxes()
         return
     end
 
-    local resolved = {}
+    -- Resolve each match to its screen box(es) first, keeping multi-line-wrapped matches
+    -- grouped together (a single match can produce several boxes, one per visual line).
+    local groups = {}
     for _, match in ipairs(self.entity_xp_matches) do
         local ok, boxes = pcall(doc.getScreenBoxesFromPositions, doc, match.start_xp, match.end_xp, true)
-        if ok and boxes then
+        if ok and boxes and #boxes > 0 then
+            local group_boxes = {}
+            local top_y, top_x = nil, nil
             for _, box in ipairs(boxes) do
-                table.insert(resolved, {
+                table.insert(group_boxes, {
                     x = box.x,
                     y = box.y,
                     w = box.w,
@@ -213,9 +217,39 @@ function M:_resolveEntityHighlightBoxes()
                     category = match.category,
                     entity_name = match.entity_name,
                 })
+                if not top_y or box.y < top_y or (box.y == top_y and box.x < top_x) then
+                    top_y, top_x = box.y, box.x
+                end
+            end
+            table.insert(groups, {
+                key = (match.category or "") .. "|" .. (match.entity_name or ""),
+                sort_y = top_y,
+                sort_x = top_x,
+                boxes = group_boxes,
+            })
+        end
+    end
+
+    -- Reading order (top-to-bottom, then left-to-right) so the per-page dedup below keeps
+    -- whichever mention appears first on the page, not an arbitrary one.
+    table.sort(groups, function(a, b)
+        if a.sort_y ~= b.sort_y then return a.sort_y < b.sort_y end
+        return a.sort_x < b.sort_x
+    end)
+
+    -- Only underline the first occurrence of a given entity per page - repeated mentions of
+    -- the same name in the same paragraph/page would otherwise clutter the text.
+    local seen = {}
+    local resolved = {}
+    for _, group in ipairs(groups) do
+        if not seen[group.key] then
+            seen[group.key] = true
+            for _, box in ipairs(group.boxes) do
+                table.insert(resolved, box)
             end
         end
     end
+
     self.entity_boxes = resolved
 end
 

--- a/xray.koplugin/xray_entityscanner.lua
+++ b/xray.koplugin/xray_entityscanner.lua
@@ -150,9 +150,30 @@ end
 function M:clearEntityUnderlines()
     self.entity_boxes = nil
     self.entity_xp_matches = nil
+    self.entity_matches_by_page = nil
     if self.ui and self.ui.view and self.ui.view.dialog then
         UIManager:setDirty(self.ui.view.dialog, "ui")
     end
+end
+
+-- Buckets matches by page once (at scan/load time) so _resolveEntityHighlightBoxes only has
+-- to call the expensive getScreenBoxesFromPositions on matches near the current page, instead
+-- of every match in the whole book on every single page turn. Only rolling (reflowable)
+-- documents expose the cheap doc:getPageFromXPointer lookup this relies on; paginated
+-- documents (PDF etc.) fall back to the unbucketed full-list resolve.
+local function _buildMatchesByPage(self, doc, matches)
+    if not self.ui or not self.ui.rolling or not doc or not doc.getPageFromXPointer then
+        return nil
+    end
+    local by_page = {}
+    for _, m in ipairs(matches) do
+        local ok, page = pcall(doc.getPageFromXPointer, doc, m.start_xp)
+        if ok and page then
+            by_page[page] = by_page[page] or {}
+            table.insert(by_page[page], m)
+        end
+    end
+    return by_page
 end
 
 function M:mountEntityUnderlineOverlay()
@@ -200,10 +221,25 @@ function M:_resolveEntityHighlightBoxes()
         return
     end
 
+    -- If matches are bucketed by page, only resolve the handful near the current page
+    -- instead of every match in the whole book (a name mentioned hundreds of times would
+    -- otherwise make every page turn scan the entire book's match list).
+    local matches_to_resolve = self.entity_xp_matches
+    if self.entity_matches_by_page then
+        local page = _getCurrentPage(self)
+        matches_to_resolve = {}
+        for _, pg in ipairs({ page - 1, page, page + 1 }) do
+            local bucket = self.entity_matches_by_page[pg]
+            if bucket then
+                for _, m in ipairs(bucket) do table.insert(matches_to_resolve, m) end
+            end
+        end
+    end
+
     -- Resolve each match to its screen box(es) first, keeping multi-line-wrapped matches
     -- grouped together (a single match can produce several boxes, one per visual line).
     local groups = {}
-    for _, match in ipairs(self.entity_xp_matches) do
+    for _, match in ipairs(matches_to_resolve) do
         local ok, boxes = pcall(doc.getScreenBoxesFromPositions, doc, match.start_xp, match.end_xp, true)
         if ok and boxes and #boxes > 0 then
             local group_boxes = {}
@@ -409,6 +445,7 @@ function M:loadEntityCache(expected_sig)
     f:close()
 
     self.entity_xp_matches = matches
+    self.entity_matches_by_page = _buildMatchesByPage(self, self.ui and self.ui.document, matches)
     self._entity_box_cache_sig = nil
     log("loadEntityCache: loaded " .. tostring(#matches) .. " matches from cache")
     if self.ui and self.ui.view then
@@ -489,6 +526,7 @@ function M:scanBookForEntities(force)
         -- _drawEntityUnderlines doesn't treat this as "never scanned" and rescan every repaint.
         self.entity_xp_matches = {}
         self.entity_boxes = {}
+        self.entity_matches_by_page = nil
         self._entity_box_cache_sig = nil
         if self.ui and self.ui.view and self.ui.view.dialog then
             UIManager:setDirty(self.ui.view.dialog, "ui")
@@ -596,6 +634,7 @@ function M:scanBookForEntities(force)
             end
 
             self.entity_xp_matches = xp_matches
+            self.entity_matches_by_page = _buildMatchesByPage(self, doc, xp_matches)
             self._entity_box_cache_sig = nil
             log("scanBookForEntities: found " .. tostring(#xp_matches) .. " entity mentions")
             progress_msg:reportProgress(95)

--- a/xray.koplugin/xray_entityscanner.lua
+++ b/xray.koplugin/xray_entityscanner.lua
@@ -1,0 +1,852 @@
+-- xray_entityscanner.lua - Underlines AI-identified entities (characters, historical figures,
+-- locations, terms) in the reading text and shows a footnote-style popup with the AI
+-- description on tap. Mirrors the scan/cache/underline/tap architecture of xray_unitscanner.lua,
+-- but matches against entities already extracted into self.characters / self.historical_figures /
+-- self.locations / self.terms instead of doing its own AI call.
+
+local UIManager = require("ui/uimanager")
+local Screen = require("device").screen
+local Blitbuffer = require("ffi/blitbuffer")
+local GestureRange = require("ui/gesturerange")
+local InputContainer = require("ui/widget/container/inputcontainer")
+local FrameContainer = require("ui/widget/container/framecontainer")
+local VerticalGroup = require("ui/widget/verticalgroup")
+local VerticalSpan = require("ui/widget/verticalspan")
+local TextBoxWidget = require("ui/widget/textboxwidget")
+local Font = require("ui/font")
+local Geom = require("ui/geometry")
+local DocSettings = require("docsettings")
+
+local plugin_path = ((...) or ""):match("(.-)[^%.]+$") or ""
+local XRayLogger = require(plugin_path .. "xray_logger")
+
+local function log(msg)
+    XRayLogger:log("EntityScanner: " .. tostring(msg))
+end
+
+local M = {}
+
+local CATEGORY_LABELS = {
+    character = "Character",
+    historical_figure = "Historical Figure",
+    location = "Location",
+    term = "Term",
+}
+
+local MIN_TERM_LEN = 3
+local MAX_REGEX_LEN = 3000
+
+-- Safe helper for current page
+local function _getCurrentPage(plugin)
+    if plugin.last_pageno then return plugin.last_pageno end
+    if plugin.ui and plugin.ui.paging and plugin.ui.paging.getCurrentPage then
+        local ok, pg = pcall(function() return plugin.ui.paging:getCurrentPage() end)
+        if ok then return pg end
+    end
+    if plugin.ui and plugin.ui.pageno then
+        return plugin.ui.pageno
+    end
+    return 1
+end
+
+local function escape_pattern(s)
+    local esc = s:gsub("([%-%+%.%?%*%^%$%(%)%[%]%%%\\])", "%%%1")
+    esc = esc:gsub("%s+", "\\s+")
+    return esc
+end
+
+local function _normalize(s)
+    return (s or ""):gsub("\194\160", " "):gsub("%s+", " "):gsub("^%s+", ""):gsub("%s+$", "")
+end
+
+-- Builds a name/alias -> {entity, category, canonical} lookup plus the flat list of
+-- unique lowercase search terms, from the already-fetched entity lists.
+local function _collectEntityTerms(self, settings)
+    local groups = {
+        { list = self.characters, category = "character", enabled = settings.entity_cat_characters ~= false },
+        { list = self.historical_figures, category = "historical_figure", enabled = settings.entity_cat_historical_figures ~= false },
+        { list = self.locations, category = "location", enabled = settings.entity_cat_locations ~= false },
+        { list = self.terms, category = "term", enabled = settings.entity_cat_terms ~= false },
+    }
+
+    local lookup = {}
+    local terms = {}
+
+    for _, group in ipairs(groups) do
+        if group.enabled and group.list then
+            for _, entity in ipairs(group.list) do
+                local names = {}
+                if entity.name and entity.name ~= "" then table.insert(names, entity.name) end
+                if entity.aliases and type(entity.aliases) == "table" then
+                    for _, alias in ipairs(entity.aliases) do
+                        if type(alias) == "string" and alias ~= "" then table.insert(names, alias) end
+                    end
+                end
+                for _, n in ipairs(names) do
+                    local clean = _normalize(n)
+                    if #clean >= MIN_TERM_LEN then
+                        local lower = clean:lower()
+                        if not lookup[lower] then
+                            lookup[lower] = { entity = entity, category = group.category, canonical = entity.name }
+                            table.insert(terms, lower)
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    return terms, lookup
+end
+
+-- Splits terms into word-boundary-safe regex chunks, each under MAX_REGEX_LEN, to stay
+-- within the text engine's regex size limits on large libraries of entities.
+local function _buildChunks(terms)
+    table.sort(terms, function(a, b) return #a > #b end)
+
+    local boundary_both = {}
+    local boundary_none = {}
+    for _, t in ipairs(terms) do
+        local esc = escape_pattern(t)
+        if t:match("^[%w]") and t:match("[%w]$") then
+            table.insert(boundary_both, esc)
+        else
+            table.insert(boundary_none, esc)
+        end
+    end
+
+    local function chunk_list(list, wrap_both)
+        local chunks = {}
+        local current = {}
+        local current_len = 0
+        for _, esc in ipairs(list) do
+            if current_len + #esc + 1 > MAX_REGEX_LEN and #current > 0 then
+                table.insert(chunks, current)
+                current = {}
+                current_len = 0
+            end
+            table.insert(current, esc)
+            current_len = current_len + #esc + 1
+        end
+        if #current > 0 then table.insert(chunks, current) end
+
+        local patterns = {}
+        for _, c in ipairs(chunks) do
+            local body = table.concat(c, "|")
+            table.insert(patterns, wrap_both and ("\\b(" .. body .. ")\\b") or ("(" .. body .. ")"))
+        end
+        return patterns
+    end
+
+    local patterns = {}
+    for _, p in ipairs(chunk_list(boundary_both, true)) do table.insert(patterns, p) end
+    for _, p in ipairs(chunk_list(boundary_none, false)) do table.insert(patterns, p) end
+    return patterns
+end
+
+-- ===== Overlay mount (paintTo) =====
+
+function M:clearEntityUnderlines()
+    self.entity_boxes = nil
+    self.entity_xp_matches = nil
+    if self.ui and self.ui.view and self.ui.view.dialog then
+        UIManager:setDirty(self.ui.view.dialog, "ui")
+    end
+end
+
+function M:mountEntityUnderlineOverlay()
+    if self._entity_paintTo_wrapped then return end
+    local view = self.ui and self.ui.view
+    if not view then return end
+    local plugin = self
+    local orig = view.paintTo
+    view.paintTo = function(view_self, bb, x, y)
+        orig(view_self, bb, x, y)
+        local ok, err = pcall(function() plugin:_drawEntityUnderlines(bb) end)
+        if not ok then
+            log("draw error: " .. tostring(err))
+        end
+    end
+    self._entity_paintTo_wrapped = true
+end
+
+local function _getEntityCacheSig(self)
+    local doc = self.ui and self.ui.document
+    if not doc then return "" end
+    local page = _getCurrentPage(self)
+    local pos = ""
+    if doc.getCurrentPos then
+        pcall(function() pos = doc:getCurrentPos() end)
+    end
+    local hash = ""
+    if doc.getDocumentRenderingHash then
+        pcall(function() hash = doc:getDocumentRenderingHash() end)
+    end
+    local sw, sh = Screen:getWidth(), Screen:getHeight()
+    return table.concat({ tostring(page), tostring(pos), tostring(hash), tostring(sw), tostring(sh) }, "|")
+end
+
+function M:_resolveEntityHighlightBoxes()
+    local sig = _getEntityCacheSig(self)
+    if self._entity_box_cache_sig == sig and self.entity_boxes then
+        return
+    end
+
+    self._entity_box_cache_sig = sig
+    local doc = self.ui and self.ui.document
+    if not doc or not self.entity_xp_matches or #self.entity_xp_matches == 0 then
+        self.entity_boxes = {}
+        return
+    end
+
+    local resolved = {}
+    for _, match in ipairs(self.entity_xp_matches) do
+        local ok, boxes = pcall(doc.getScreenBoxesFromPositions, doc, match.start_xp, match.end_xp, true)
+        if ok and boxes then
+            for _, box in ipairs(boxes) do
+                table.insert(resolved, {
+                    x = box.x,
+                    y = box.y,
+                    w = box.w,
+                    h = box.h,
+                    matched_text = match.matched_text,
+                    category = match.category,
+                    entity_name = match.entity_name,
+                })
+            end
+        end
+    end
+    self.entity_boxes = resolved
+end
+
+local function _checkEntitySettingsChanged(self)
+    local settings = self.ai_helper and self.ai_helper.settings or {}
+    local enabled = settings.entity_footnotes_enabled ~= false
+    local cat_c = settings.entity_cat_characters ~= false
+    local cat_h = settings.entity_cat_historical_figures ~= false
+    local cat_l = settings.entity_cat_locations ~= false
+    local cat_t = settings.entity_cat_terms ~= false
+    local style = settings.unit_underline_style or "wavy"
+    local thickness = settings.unit_underline_thickness or 2
+    local intensity = settings.unit_underline_intensity or "light"
+
+    if self.last_entity_settings_state == nil then
+        self.last_entity_settings_state = {
+            enabled = enabled, cat_c = cat_c, cat_h = cat_h, cat_l = cat_l, cat_t = cat_t,
+            style = style, thickness = thickness, intensity = intensity,
+        }
+        return false, false
+    end
+
+    local state = self.last_entity_settings_state
+    local scan_changed = (state.enabled ~= enabled) or (state.cat_c ~= cat_c) or
+                         (state.cat_h ~= cat_h) or (state.cat_l ~= cat_l) or (state.cat_t ~= cat_t)
+    local draw_changed = (state.style ~= style) or (state.thickness ~= thickness) or (state.intensity ~= intensity)
+
+    if scan_changed or draw_changed then
+        self.last_entity_settings_state = {
+            enabled = enabled, cat_c = cat_c, cat_h = cat_h, cat_l = cat_l, cat_t = cat_t,
+            style = style, thickness = thickness, intensity = intensity,
+        }
+    end
+
+    return scan_changed, draw_changed
+end
+
+function M:_drawEntityUnderlines(bb)
+    local scan_needed, redraw_needed = _checkEntitySettingsChanged(self)
+    if scan_needed then
+        log("Entity settings changed, refreshing entity scan")
+        self:scanBookForEntities()
+        self._entity_box_cache_sig = nil
+    elseif redraw_needed then
+        self._entity_box_cache_sig = nil
+    end
+
+    local settings = self.ai_helper and self.ai_helper.settings or {}
+    if settings.entity_footnotes_enabled == false then
+        if self.entity_boxes and #self.entity_boxes > 0 then
+            self:clearEntityUnderlines()
+        end
+        return
+    end
+
+    if not self.entity_xp_matches then
+        local cache_loaded = self:loadEntityCache()
+        if not cache_loaded then
+            self:scanBookForEntities()
+        end
+    end
+
+    self:_resolveEntityHighlightBoxes()
+    if not self.entity_boxes or #self.entity_boxes == 0 then return end
+
+    local underline_style = settings.unit_underline_style or "wavy"
+    if underline_style == "invisible" then return end
+
+    local raw_thickness = tonumber(settings.unit_underline_thickness) or 2
+    local thickness = Screen:scaleBySize(raw_thickness)
+    local intensity = settings.unit_underline_intensity or "light"
+
+    local grey = 150
+    if intensity == "light" then
+        grey = 200
+    elseif intensity == "dark" then
+        grey = 30
+    end
+
+    for _, box in ipairs(self.entity_boxes) do
+        if box.x and box.y and box.w and box.h then
+            self._draw_underline(bb, box, underline_style, grey, thickness, raw_thickness, self.path)
+        end
+    end
+end
+
+-- ===== Cache =====
+
+function M:_getEntityCachePath()
+    if not self.ui or not self.ui.document or not self.ui.document.file then return nil end
+    local sidecar = DocSettings:getSidecarDir(self.ui.document.file)
+    if not sidecar then return nil end
+    return sidecar .. "/xray_entity_cache.cache"
+end
+
+-- Signature covers both the enabled categories and the entity data itself (name lists),
+-- so the cache self-invalidates once the AI has fetched more characters/locations/etc,
+-- without needing to hook every fetch completion path.
+local function _getEntitySettingsSignature(self, settings)
+    local function sig_list(list)
+        local parts = {}
+        if list then
+            for _, e in ipairs(list) do
+                table.insert(parts, e.name or "")
+            end
+        end
+        return table.concat(parts, ",")
+    end
+
+    local cat_c = settings.entity_cat_characters ~= false
+    local cat_h = settings.entity_cat_historical_figures ~= false
+    local cat_l = settings.entity_cat_locations ~= false
+    local cat_t = settings.entity_cat_terms ~= false
+
+    return table.concat({
+        "v1",
+        tostring(cat_c), tostring(cat_h), tostring(cat_l), tostring(cat_t),
+        sig_list(self.characters), sig_list(self.historical_figures),
+        sig_list(self.locations), sig_list(self.terms),
+    }, "|")
+end
+
+function M:loadEntityCache(expected_sig)
+    local cache_file = self:_getEntityCachePath()
+    if not cache_file then return false end
+
+    local f = io.open(cache_file, "r")
+    if not f then return false end
+
+    local signature = f:read("*l")
+    if not signature then
+        f:close()
+        return false
+    end
+    signature = signature:gsub("%s+$", "")
+
+    local settings = self.ai_helper and self.ai_helper.settings or {}
+    expected_sig = expected_sig or _getEntitySettingsSignature(self, settings)
+    if signature ~= expected_sig then
+        f:close()
+        return false
+    end
+
+    local matches = {}
+    for line in f:lines() do
+        line = line:gsub("\r", "")
+        local start_xp, end_xp, matched_text, category, entity_name = line:match("^([^\t]*)\t([^\t]*)\t([^\t]*)\t([^\t]*)\t([^\t]*)$")
+        if start_xp then
+            table.insert(matches, {
+                start_xp = start_xp,
+                end_xp = end_xp,
+                matched_text = matched_text,
+                category = category,
+                entity_name = entity_name,
+            })
+        end
+    end
+    f:close()
+
+    self.entity_xp_matches = matches
+    self._entity_box_cache_sig = nil
+    log("loadEntityCache: loaded " .. tostring(#matches) .. " matches from cache")
+    if self.ui and self.ui.view then
+        if self.ui.view.dialog then
+            UIManager:setDirty(self.ui.view.dialog, "ui")
+        end
+        UIManager:setDirty(nil, "ui")
+    end
+    return true
+end
+
+function M:saveEntityCache(signature)
+    local cache_file = self:_getEntityCachePath()
+    if not cache_file then return end
+
+    local settings = self.ai_helper and self.ai_helper.settings or {}
+    signature = signature or _getEntitySettingsSignature(self, settings)
+
+    local dir = cache_file:match("^(.+)/[^/]+$")
+    if dir then
+        local ok_lfs, lfs = pcall(require, "libs/libkoreader-lfs")
+        if ok_lfs and lfs then
+            if lfs.attributes(dir, "mode") ~= "directory" then
+                lfs.mkdir(dir)
+            end
+        end
+    end
+
+    local ok, err = pcall(function()
+        local f, open_err = io.open(cache_file, "w")
+        if f then
+            f:write(signature .. "\n")
+            for _, m in ipairs(self.entity_xp_matches or {}) do
+                local matched_clean = (m.matched_text or ""):gsub("\r", " "):gsub("\n", " ")
+                local name_clean = (m.entity_name or ""):gsub("\r", " "):gsub("\n", " ")
+                f:write(string.format("%s\t%s\t%s\t%s\t%s\n",
+                    tostring(m.start_xp or ""),
+                    tostring(m.end_xp or ""),
+                    matched_clean,
+                    m.category or "",
+                    name_clean))
+            end
+            f:close()
+        else
+            log("saveEntityCache: failed to open cache: " .. tostring(open_err))
+        end
+    end)
+    if not ok then
+        log("saveEntityCache: unexpected error writing cache: " .. tostring(err))
+    end
+end
+
+-- ===== Scan =====
+
+function M:scanBookForEntities(force)
+    if not self.ui or not self.ui.document then return end
+
+    local settings = self.ai_helper and self.ai_helper.settings or {}
+    if settings.entity_footnotes_enabled == false then
+        self:clearEntityUnderlines()
+        return
+    end
+
+    if self._entity_scan_in_progress then return end
+
+    local resolved_sig = _getEntitySettingsSignature(self, settings)
+    if not force then
+        local cache_loaded = self:loadEntityCache(resolved_sig)
+        if cache_loaded then
+            log("scanBookForEntities: returning early due to cached hits")
+            return
+        end
+    end
+
+    local terms, lookup = _collectEntityTerms(self, settings)
+    if #terms == 0 then
+        self.entity_xp_matches = {}
+        self:clearEntityUnderlines()
+        return
+    end
+
+    self._entity_scan_in_progress = true
+    local doc = self.ui.document
+
+    local Notification = require("ui/widget/notification")
+    UIManager:show(Notification:new{
+        text = self.loc:t("entity_scanning_book") or "Scanning book for footnotes...",
+        timeout = 2,
+        toast = true,
+    })
+
+    UIManager:scheduleIn(0.1, function()
+        if self.destroyed then
+            self._entity_scan_in_progress = false
+            return
+        end
+
+        local ok_scan, err_scan = pcall(function()
+            local patterns = _buildChunks(terms)
+            local hits = {}
+            for _, pat in ipairs(patterns) do
+                local ok1, hits1 = pcall(function()
+                    return doc:findAllText(pat, true, 0, 5000, true)
+                end)
+                if ok1 and hits1 then
+                    for _, h in ipairs(hits1) do table.insert(hits, h) end
+                else
+                    log("scanBookForEntities: findAllText pcall failed (non-fatal): " .. tostring(hits1))
+                end
+            end
+
+            -- Deduplicate overlapping hits by end xpointer, keeping the longest match
+            local unique_hits = {}
+            for _, hit in ipairs(hits) do
+                local end_xp = hit["end"]
+                if not unique_hits[end_xp] or #hit.matched_text > #unique_hits[end_xp].matched_text then
+                    unique_hits[end_xp] = hit
+                end
+            end
+
+            local xp_matches = {}
+            for _, hit in pairs(unique_hits) do
+                local matched = _normalize(hit.matched_text or "")
+                local entry = lookup[matched:lower()]
+                if entry then
+                    table.insert(xp_matches, {
+                        start_xp = hit.start,
+                        end_xp = hit["end"],
+                        matched_text = matched,
+                        category = entry.category,
+                        entity_name = entry.canonical,
+                    })
+                end
+            end
+
+            self.entity_xp_matches = xp_matches
+            self._entity_box_cache_sig = nil
+            log("scanBookForEntities: found " .. tostring(#xp_matches) .. " entity mentions")
+
+            UIManager:show(Notification:new{
+                text = tostring(#xp_matches) .. " footnotes found",
+                timeout = 3,
+                toast = true,
+            })
+            if self.ui and self.ui.view then
+                if self.ui.view.dialog then
+                    UIManager:setDirty(self.ui.view.dialog, "ui")
+                end
+                UIManager:setDirty(nil, "ui")
+            end
+
+            UIManager:scheduleIn(0.5, function()
+                if not self.destroyed then
+                    self:saveEntityCache(resolved_sig)
+                end
+            end)
+        end)
+
+        self._entity_scan_in_progress = false
+        if not ok_scan then
+            log("scanBookForEntities async error: " .. tostring(err_scan))
+        end
+    end)
+end
+
+-- ===== Tooltip / footnote popup =====
+
+local function _getPopupFontSize(plugin)
+    local size
+    if plugin and plugin.ui and plugin.ui.font and plugin.ui.font.configurable then
+        size = plugin.ui.font.configurable.font_size
+    elseif G_reader_settings then
+        size = G_reader_settings:readSetting("cre_font_size")
+              or G_reader_settings:readSetting("kopt_font_size")
+    end
+    if size then return size end
+    if Screen.scaleBySize then
+        return Screen:scaleBySize(22)
+    end
+    return 22
+end
+
+local function getFontSafe(preferred_family, size)
+    if preferred_family and preferred_family ~= "" then
+        local ok, credoc = pcall(require, "document/credocument")
+        if ok and credoc and credoc.engineInit then
+            local ok2, cre = pcall(credoc.engineInit, credoc)
+            if ok2 and cre and cre.getFontFaceFilenameAndFaceIndex then
+                local filename, faceindex = cre.getFontFaceFilenameAndFaceIndex(preferred_family)
+                if not filename then
+                    filename, faceindex = cre.getFontFaceFilenameAndFaceIndex(preferred_family, nil, true)
+                end
+                if filename then
+                    local face_ok, face = pcall(Font.getFace, Font, filename, size, faceindex)
+                    if face_ok and face then return face end
+                end
+            end
+        end
+    end
+    return Font:getFace("cfont", size)
+end
+
+local EntityFootnote = InputContainer:extend{
+    box = nil,
+    entity = nil,
+    category = nil,
+    title_text = "",
+    description_text = "",
+    plugin = nil,
+    timeout = 8,
+    timer_handle = nil,
+    _closed = false,
+}
+
+function EntityFootnote:init()
+    local sw, sh = Screen:getWidth(), Screen:getHeight()
+    local sc = function(n) return Screen:scaleBySize(n) end
+
+    local fs = _getPopupFontSize(self.plugin)
+    local doc_family
+    if self.plugin and self.plugin.ui and self.plugin.ui.font then
+        doc_family = self.plugin.ui.font.font_face
+    end
+    if not doc_family and G_reader_settings then
+        doc_family = G_reader_settings:readSetting("cre_font_family")
+    end
+    local face = getFontSafe(doc_family, fs)
+    local small_face = getFontSafe(doc_family, math.max(12, fs - 4))
+
+    local pad_h = 24
+    local pad_v = math.floor(fs * 0.55)
+    local card_w = math.floor(math.min(sw, sh) * 0.82)
+    local text_w = card_w - pad_h * 2
+
+    local vg = VerticalGroup:new{ align = "left" }
+    table.insert(vg, TextBoxWidget:new{
+        text = self.title_text,
+        face = face,
+        width = text_w,
+        bold = true,
+    })
+
+    local label = CATEGORY_LABELS[self.category]
+    if label then
+        table.insert(vg, VerticalSpan:new{ width = math.max(2, math.floor(fs * 0.15)) })
+        table.insert(vg, TextBoxWidget:new{
+            text = label,
+            face = small_face,
+            width = text_w,
+        })
+    end
+
+    table.insert(vg, VerticalSpan:new{ width = math.max(6, math.floor(fs * 0.35)) })
+    table.insert(vg, TextBoxWidget:new{
+        text = self.description_text,
+        face = face,
+        width = text_w,
+    })
+
+    local card = FrameContainer:new{
+        background = Blitbuffer.COLOR_WHITE,
+        bordersize = sc(2),
+        color = Blitbuffer.COLOR_DARK_GRAY,
+        radius = 0,
+        padding_top = pad_v,
+        padding_bottom = pad_v,
+        padding_left = pad_h,
+        padding_right = pad_h,
+        width = card_w,
+        vg,
+    }
+
+    local card_size = card:getSize()
+    card_w = card_size.w
+    local card_h = math.min(card_size.h, sh - sc(40))
+
+    local margin = sc(10)
+    local box = self.box
+    local ref_x = box.x + box.w / 2
+    local ref_bottom = box.y + box.h
+    local ref_top = box.y
+
+    local arrow_w = sc(16)
+    local arrow_h = sc(8)
+    local border_px = sc(2)
+
+    local popup_x = math.max(0, math.min(sw - card_w, math.floor(ref_x - card_w / 2)))
+    local popup_y
+    local popup_below_word
+    if ref_bottom + margin + card_h <= sh then
+        popup_y = ref_bottom + margin
+        popup_below_word = true
+    else
+        popup_y = ref_top - margin - card_h - arrow_h + border_px
+        popup_below_word = false
+    end
+
+    if popup_below_word then
+        popup_y = math.max(arrow_h - border_px, math.min(sh - card_h, popup_y))
+    else
+        popup_y = math.max(0, math.min(sh - card_h - arrow_h + border_px, popup_y))
+    end
+    card.overlap_offset = { popup_x, popup_y }
+
+    local apex_min = popup_x + arrow_w / 2 + sc(4)
+    local apex_max = popup_x + card_w - arrow_w / 2 - sc(4)
+    local apex_x
+    if apex_min <= apex_max then
+        apex_x = math.max(apex_min, math.min(apex_max, ref_x))
+    else
+        apex_x = popup_x + card_w / 2
+    end
+
+    local arrow_x = math.floor(apex_x - arrow_w / 2)
+    local arrow_y
+    local arrow_dir
+    if popup_below_word then
+        arrow_dir = "up"
+        arrow_y = popup_y - arrow_h + border_px
+    else
+        arrow_dir = "down"
+        arrow_y = popup_y + card_h - border_px
+    end
+
+    local PointerArrowClass = self.plugin and self.plugin._PointerArrow
+    local arrow
+    if PointerArrowClass then
+        arrow = PointerArrowClass:new{
+            width = arrow_w,
+            height = arrow_h,
+            direction = arrow_dir,
+            apex_offset = arrow_w / 2,
+            border_size = border_px,
+            border_color = Blitbuffer.COLOR_DARK_GRAY,
+            fill_color = Blitbuffer.COLOR_WHITE,
+        }
+        arrow.overlap_offset = { arrow_x, arrow_y }
+    end
+
+    self.dimen = Geom:new{ x = 0, y = 0, w = sw, h = sh }
+    self.ges_events = {
+        TapOutside = {
+            GestureRange:new{
+                ges = "tap",
+                range = Geom:new{ x = 0, y = 0, w = sw, h = sh }
+            }
+        }
+    }
+
+    local OverlapGroup = require("ui/widget/overlapgroup")
+    local children = { dimen = Geom:new{ w = sw, h = sh }, card }
+    if arrow then table.insert(children, arrow) end
+    self[1] = OverlapGroup:new(children)
+end
+
+function EntityFootnote:onTapOutside()
+    self:dismiss()
+    return true
+end
+
+function EntityFootnote:onClose()
+    self:dismiss()
+    return true
+end
+
+function EntityFootnote:dismiss()
+    if self.timer_handle then
+        pcall(function() self.timer_handle:cancel() end)
+        self.timer_handle = nil
+    end
+    if not self._closed then
+        self._closed = true
+        UIManager:close(self)
+    end
+end
+
+function EntityFootnote:onShow()
+    if self.timeout and self.timeout > 0 then
+        local this = self
+        self.timer_handle = UIManager:scheduleIn(self.timeout, function()
+            if not this._closed then
+                this:dismiss()
+            end
+        end)
+    end
+    UIManager:setDirty(self, "ui")
+    return true
+end
+
+function M:_findEntityByNameAndCategory(name, category)
+    local list
+    if category == "character" then list = self.characters
+    elseif category == "historical_figure" then list = self.historical_figures
+    elseif category == "location" then list = self.locations
+    elseif category == "term" then list = self.terms
+    end
+    if not list then return nil end
+
+    local lower = (name or ""):lower()
+    for _, e in ipairs(list) do
+        if (e.name or ""):lower() == lower then return e end
+    end
+    return nil
+end
+
+function M:showEntityFootnote(box)
+    if not box then return end
+    local entity = self:_findEntityByNameAndCategory(box.entity_name, box.category)
+    if not entity then return end
+
+    local desc
+    if box.category == "term" then
+        desc = entity.definition or entity.expanded
+    elseif self.resolveDescriptionForPage then
+        local current_page = _getCurrentPage(self)
+        desc = self:resolveDescriptionForPage(entity, current_page)
+    else
+        desc = entity.description or entity.biography
+    end
+    if not desc or desc == "" or desc == "---" then
+        desc = self.loc:t("entity_no_description") or "No description available yet."
+    end
+
+    local settings = self.ai_helper and self.ai_helper.settings or {}
+    local timeout = tonumber(settings.entity_tooltip_timeout) or 8
+
+    local footnote = EntityFootnote:new{
+        box = box,
+        entity = entity,
+        category = box.category,
+        title_text = entity.name or box.matched_text or "",
+        description_text = desc,
+        plugin = self,
+        timeout = timeout,
+    }
+    UIManager:show(footnote)
+end
+
+-- ===== Tap handling =====
+
+-- Mount tap handler via monkey patching self.ui.highlight.onTap. Chains after the unit
+-- converter's tap handler (if mounted), so both features can coexist without conflicting.
+function M:mountEntityTapHandler()
+    if self._entityTapHandler_wrapped then return end
+    local plugin = self
+    local hl = self.ui and self.ui.highlight
+    if not hl then return end
+    local orig_tap = hl.onTap
+    hl.onTap = function(hl_self, _, ges)
+        if ges and plugin:_handleEntityTap(ges) then return true end
+        if orig_tap then return orig_tap(hl_self, _, ges) end
+    end
+    self._entityTapHandler_wrapped = true
+end
+
+function M:_handleEntityTap(ges)
+    local settings = self.ai_helper and self.ai_helper.settings or {}
+    if settings.entity_footnotes_enabled == false then return false end
+
+    if not self.entity_boxes or #self.entity_boxes == 0 then
+        return false
+    end
+    local tx, ty = ges.pos.x, ges.pos.y
+    for _, box in ipairs(self.entity_boxes) do
+        if tx >= box.x and tx <= box.x + box.w
+        and ty >= box.y - 6 and ty <= box.y + box.h + 6 then
+            self:showEntityFootnote(box)
+            return true
+        end
+    end
+    return false
+end
+
+return M

--- a/xray.koplugin/xray_entityscanner.lua
+++ b/xray.koplugin/xray_entityscanner.lua
@@ -261,22 +261,20 @@ function M:_drawEntityUnderlines(bb)
         self._entity_box_cache_sig = nil
     elseif redraw_needed then
         self._entity_box_cache_sig = nil
+
+        local settings = self.ai_helper and self.ai_helper.settings or {}
+        if settings.entity_footnotes_enabled == false then
+            self:clearEntityUnderlines()
+        elseif not self.entity_xp_matches then
+            local cache_loaded = self:loadEntityCache()
+            if not cache_loaded then
+                self:scanBookForEntities()
+            end
+        end
     end
 
     local settings = self.ai_helper and self.ai_helper.settings or {}
-    if settings.entity_footnotes_enabled == false then
-        if self.entity_boxes and #self.entity_boxes > 0 then
-            self:clearEntityUnderlines()
-        end
-        return
-    end
-
-    if not self.entity_xp_matches then
-        local cache_loaded = self:loadEntityCache()
-        if not cache_loaded then
-            self:scanBookForEntities()
-        end
-    end
+    if settings.entity_footnotes_enabled == false then return end
 
     self:_resolveEntityHighlightBoxes()
     if not self.entity_boxes or #self.entity_boxes == 0 then return end
@@ -452,8 +450,14 @@ function M:scanBookForEntities(force)
 
     local terms, lookup = _collectEntityTerms(self, settings)
     if #terms == 0 then
+        -- Mark as "scanned, nothing to show" (not nil) so the paint-time check in
+        -- _drawEntityUnderlines doesn't treat this as "never scanned" and rescan every repaint.
         self.entity_xp_matches = {}
-        self:clearEntityUnderlines()
+        self.entity_boxes = {}
+        self._entity_box_cache_sig = nil
+        if self.ui and self.ui.view and self.ui.view.dialog then
+            UIManager:setDirty(self.ui.view.dialog, "ui")
+        end
         return
     end
 

--- a/xray.koplugin/xray_fetch.lua
+++ b/xray.koplugin/xray_fetch.lua
@@ -310,8 +310,9 @@ function M:_processSingleWordResult(result, text, book_text, current_page)
             updated.book_type = self.book_type or updated.book_type
             updated.author_info = self.author_info or updated.author_info
             updated.last_fetch_page = updated.last_fetch_page
-            
+
             self.cache_manager:asyncSaveCache(self.ui.document.file, updated)
+            if self.scanBookForEntities then self:scanBookForEntities() end
         end
         
         -- Always show result if it's valid, even if it didn't merge into a target_list
@@ -942,6 +943,7 @@ function M:finalizeXRayData(final_book_data, title, author, book_text, is_update
 
     if not self.cache_manager then self.cache_manager = require(plugin_path .. "xray_cachemanager"):new() end
     local cache_saved = self.cache_manager:asyncSaveCache(self.ui.document.file, updated_data)
+    if self.scanBookForEntities then self:scanBookForEntities() end
 
     -- If book is part of a series, update this book's entry in SeriesCache
     if self.series_manager and (updated_data.series_slug or (self.ui and self.ui.document)) then
@@ -1292,8 +1294,9 @@ function M:fetchMoreCharacters()
             updated_data.book_type = self.book_type or updated_data.book_type
             updated_data.timeline = self.timeline or updated_data.timeline
             updated_data.author_info = self.author_info or updated_data.author_info
-            
+
             self.cache_manager:asyncSaveCache(self.ui.document.file, updated_data)
+            if self.scanBookForEntities then self:scanBookForEntities() end
 
             local current_page = self.ui and self.ui.getCurrentPage and self.ui:getCurrentPage() or 1
             local total_pages = self.ui and self.ui.document and self.ui.document.getPageCount and self.ui.document:getPageCount() or 1
@@ -1445,9 +1448,10 @@ function M:fetchMoreTerms()
             updated_data.book_type = self.book_type or updated_data.book_type
             updated_data.timeline = self.timeline or updated_data.timeline
             updated_data.author_info = self.author_info or updated_data.author_info
-            
+
             self.cache_manager:asyncSaveCache(self.ui.document.file, updated_data)
-            
+            if self.scanBookForEntities then self:scanBookForEntities() end
+
             local added_msg = self.loc:t("msg_added_terms", new_count)
             UIManager:show(InfoMessage:new{ text = added_msg, timeout = 3 })
 
@@ -1729,6 +1733,7 @@ function M:mergeSeriesContext(cache_data, series_info)
         cache.timeline = self.timeline
         self.cache_manager:asyncSaveCache(book_path, cache)
         self.book_data = cache
+        if self.scanBookForEntities then self:scanBookForEntities() end
     end
 end
 


### PR DESCRIPTION
## Summary

Adds an "Entity Footnotes" feature that underlines AI-identified entities (characters, historical figures, locations, and terms) directly in the reading text, and shows a footnote-style popup with the AI-generated description when tapped - the same in-text interaction pattern the Unit Converter already uses for measurement conversions.

- New `xray_entityscanner.lua` module, mirroring the scan/cache/underline/tap-handler architecture of `xray_unitscanner.lua`:
  - Matches page text against entities already extracted into `self.characters` / `self.historical_figures` / `self.locations` / `self.terms` (no extra AI calls - reuses whatever X-Ray has already fetched for the book).
  - Chunked, word-boundary-safe regex scan via `doc:findAllText`, with results cached to a sidecar file (invalidated automatically when the entity list grows/changes or category settings change).
  - Reuses the existing wavy/dotted/dashed/double underline renderer (`self._draw_underline`) and pointer-arrow widget (`self._PointerArrow`) exposed by the unit converter, so both features share one visual language.
  - New `EntityFootnote` popup (wrapped multi-line title + category label + description) instead of the single-line unit tooltip, sized for longer AI descriptions.
  - Tap handling chains after the unit converter's tap handler so both can coexist without conflicts.
  - Spoiler-safe: uses the existing `resolveDescriptionForPage` helper so a character's underlined description only reveals what's been fetched up to the reader's current page.
  - Only the first occurrence of a given entity per page is underlined; repeated mentions in the same paragraph/page don't clutter the text (multi-line-wrapped matches are still kept together as one underline).
  - **Runs as a chunked background task, not a blocking scan.** Unlike the Unit Converter (which scans once at book open), this scan is re-triggered every time new entity data arrives (`fetchMoreCharacters`, `fetchMoreTerms`, `mergeSeriesContext`), so a blocking modal was not acceptable UX - it would freeze reading every time the AI found a new character. The regex-chunk loop now processes one chunk per event-loop tick via `UIManager:scheduleIn(0, step)`, yielding back to KOReader between chunks so page turns, taps, and menu input stay responsive while a scan runs. Feedback is a non-blocking toast (only shown for scans with 3+ chunks) instead of a modal dialog.
  - Matches are bucketed by page at scan/cache-load time (via the cheap `doc:getPageFromXPointer` lookup) so page turns only resolve underline positions for the current page, not the whole book - character names can appear far more often than unit conversions, so the naive whole-book resolve (the same pattern the Unit Converter already uses) scaled noticeably worse here. Paginated documents (PDF etc.), which don't expose that lookup, fall back unchanged to the original full-list resolve.
- `main.lua`: mounts the overlay/tap handler and triggers an initial scan alongside the unit converter at `onReaderReady`; adds an "Entity Footnotes" menu section (enable toggle, manual rescan, per-category toggles for Characters/Historical Figures/Locations/Terms, and reuses the existing Style & Underline Settings card).
- `xray_fetch.lua`: triggers a rescan at the points where new characters/locations/historical figures/terms are fetched and cached, so newly discovered entities get underlined without waiting for a book reopen. Safe to call often: the in-progress guard skips overlapping scans, and the signature-based cache means a skipped trigger is picked up by the next one once the entity list has actually changed.
- `languages/en.po`: registers the new menu/settings strings (other languages still need translations contributed - `Localization:t()` returns the raw key, not a fallback, for unregistered keys).

## Test plan

- [x] `luac5.1 -p` syntax-checked on all added/modified files - clean.
- [x] **Tested on-device end to end** (EPUB, reflowable): underlines appear on already-fetched characters/locations, tap shows the footnote popup with the correct description, category toggles and the enable switch update underlines live, coexists correctly with the Unit Converter's underlines/taps on the same page, sidecar cache survives a book reopen and rescans automatically once more characters are fetched.
- [ ] Not yet tested on a paginated document (PDF/CBZ) - the page-turn performance optimization intentionally no-ops there and falls back to the original (pre-existing) full-list resolve, so it should be no worse than before, but hasn't been directly verified.
- [ ] Chunked/non-blocking rescan (responsiveness while a mid-read rescan is in flight, e.g. right after `fetchMoreCharacters` returns) not yet re-verified on-device since the latest commit - flagging for review/testing before merge.
