### PR TITLE
Fix AI request cancellation across suspend and timeout. Add cancel button to inline lookups. 

### DIFF
--- a/spec/xray_fetch_spec.lua
+++ b/spec/xray_fetch_spec.lua
@@ -77,6 +77,24 @@ describe("xray_fetch", function()
 
             assert.is_true(cancelled)
         end)
+
+        it("still kills the helper child when a registered callback is stale", function()
+            local callback_called = false
+            local child_cancelled = false
+            plugin._active_ai_cancel = function() callback_called = true end
+            plugin.ai_helper = {
+                _async_child_pid = 88,
+                cancelAsyncChild = function(self)
+                    child_cancelled = true
+                    self._async_child_pid = nil
+                end,
+            }
+
+            plugin:cancelActiveAIRequest("device suspended")
+
+            assert.is_true(callback_called)
+            assert.is_true(child_cancelled)
+        end)
     end)
 
     describe("runPostFetchDuplicateCheck reader state", function()
@@ -134,6 +152,28 @@ describe("xray_fetch", function()
     end)
 
     describe("continueWithFetch cancellation", function()
+        it("does not let a silent fetch replace another request's cancel handler", function()
+            local original_cancel = function() end
+            local scheduled = false
+            local UIManager = require("ui/uimanager")
+            local old_schedule = UIManager.scheduleIn
+            UIManager.scheduleIn = function()
+                scheduled = true
+            end
+            plugin._active_ai_cancel = original_cancel
+            plugin.bg_fetch_pending = true
+
+            local ok, err = pcall(function()
+                plugin:continueWithFetch(50, true, nil, true)
+                assert.are.equal(original_cancel, plugin._active_ai_cancel)
+                assert.is_false(plugin.bg_fetch_pending)
+                assert.is_false(scheduled)
+            end)
+
+            UIManager.scheduleIn = old_schedule
+            if not ok then error(err) end
+        end)
+
         it("cancels the owned child and allows a new fetch before the old poll runs", function()
             local UIManager = require("ui/uimanager")
             local old_schedule = UIManager.scheduleIn

--- a/spec/xray_fetch_spec.lua
+++ b/spec/xray_fetch_spec.lua
@@ -197,6 +197,7 @@ describe("xray_fetch", function()
                 assert.are.equal(501, cancelled_pids[1])
                 assert.is_false(plugin.bg_fetch_active)
                 assert.is_true(#removed_files > 0)
+                assert.are.equal(first_dialog, _G.ui_tracker.closed[#_G.ui_tracker.closed])
 
                 -- Start again before the cancelled fetch's queued poll runs.
                 plugin:continueWithFetch(50)
@@ -533,6 +534,43 @@ describe("xray_fetch", function()
                 assert.are.equal(1001, cancelled_pid)
                 assert.is_nil(plugin._active_ai_dialog)
                 assert.is_nil(plugin._active_ai_cancel)
+            end)
+
+            UIManager.scheduleIn = old_schedule
+            if not ok then error(err) end
+        end)
+
+        it("does not spawn a lookup child when cancelled before deferred analysis", function()
+            local UIManager = require("ui/uimanager")
+            local old_schedule = UIManager.scheduleIn
+            local scheduled = {}
+            local spawn_count = 0
+
+            UIManager.scheduleIn = function(self, delay, callback)
+                table.insert(scheduled, callback)
+            end
+            plugin.ui.getCurrentPage = function() return 1 end
+            plugin.chapter_analyzer = {
+                getDetailedChapterSamples = function() return {}, {} end,
+                getEndPageForCurrentPage = function() return 1 end,
+                getTextFromPageRange = function() return "book text" end,
+            }
+            plugin.ai_helper = {
+                hasApiKey = function() return true end,
+                lookupSingleWordAsync = function()
+                    spawn_count = spawn_count + 1
+                    return 1001
+                end,
+                cancelAsyncChild = function() return true end,
+            }
+
+            local ok, err = pcall(function()
+                plugin:fetchSingleWord("TestTerm", 1, 2)
+                plugin._active_ai_dialog.args.buttons[1][1].callback()
+                while #scheduled > 0 do
+                    table.remove(scheduled, 1)()
+                end
+                assert.are.equal(0, spawn_count)
             end)
 
             UIManager.scheduleIn = old_schedule

--- a/spec/xray_fetch_spec.lua
+++ b/spec/xray_fetch_spec.lua
@@ -18,6 +18,67 @@ describe("xray_fetch", function()
         }
     end)
 
+    describe("request deadlines", function()
+        it("uses elapsed wall time so suspend cannot extend a timeout", function()
+            local old_time = os.time
+            os.time = function() return 1601 end
+
+            local ok, timed_out = pcall(function()
+                return plugin:isRequestTimedOut(1000, 600)
+            end)
+
+            os.time = old_time
+            if not ok then error(timed_out) end
+            assert.is_true(timed_out)
+        end)
+
+        it("keeps requests active before their wall-clock deadline", function()
+            local old_time = os.time
+            os.time = function() return 1299 end
+
+            local ok, timed_out = pcall(function()
+                return plugin:isRequestTimedOut(1000, 300)
+            end)
+
+            os.time = old_time
+            if not ok then error(timed_out) end
+            assert.is_false(timed_out)
+        end)
+    end)
+
+    describe("active request cleanup", function()
+        it("cancels the registered operation and clears suspend-sensitive state", function()
+            local cancelled_reason
+            local dialog = { type = "ButtonDialog" }
+            plugin._active_ai_dialog = dialog
+            plugin._active_ai_cancel = function(reason) cancelled_reason = reason end
+            plugin._active_fetch_generation = 4
+            plugin.bg_fetch_active = true
+            plugin.bg_fetch_pending = true
+
+            plugin:cancelActiveAIRequest("device suspended")
+
+            assert.are.equal("device suspended", cancelled_reason)
+            assert.is_nil(plugin._active_ai_dialog)
+            assert.is_nil(plugin._active_ai_cancel)
+            assert.is_nil(plugin._active_fetch_generation)
+            assert.is_false(plugin.bg_fetch_active)
+            assert.is_false(plugin.bg_fetch_pending)
+        end)
+
+        it("kills an unregistered orphan child", function()
+            local cancelled = false
+            plugin.ai_helper = {
+                _async_child_pid = 77,
+                cancelAsyncChild = function() cancelled = true end,
+            }
+
+            plugin:cancelActiveAIRequest("device suspended")
+
+            assert.is_true(cancelled)
+        end)
+    end)
+
     describe("runPostFetchDuplicateCheck reader state", function()
         it("skips safely when the reader document is unavailable", function()
             local analyzer_called = false
@@ -439,6 +500,43 @@ describe("xray_fetch", function()
             
             plugin:fetchSingleWord("TestTerm", 1, 2)
             assert.is_true(cancelled)
+        end)
+
+        it("shows a Cancel button that terminates the lookup child", function()
+            local UIManager = require("ui/uimanager")
+            local old_schedule = UIManager.scheduleIn
+            local scheduled = {}
+            local cancelled_pid
+
+            UIManager.scheduleIn = function(self, delay, callback)
+                table.insert(scheduled, callback)
+            end
+            plugin.ui.getCurrentPage = function() return 1 end
+            plugin.chapter_analyzer = {
+                getDetailedChapterSamples = function() return {}, {} end,
+                getEndPageForCurrentPage = function() return 1 end,
+                getTextFromPageRange = function() return "book text" end,
+            }
+            plugin.ai_helper = {
+                hasApiKey = function() return true end,
+                lookupSingleWordAsync = function() return 1001 end,
+                cancelAsyncChild = function(_, pid) cancelled_pid = pid; return true end,
+                checkAsyncResult = function() return nil end,
+            }
+
+            local ok, err = pcall(function()
+                plugin:fetchSingleWord("TestTerm", 1, 2)
+                assert.are.equal("ButtonDialog", plugin._active_ai_dialog.type)
+                table.remove(scheduled, 1)()
+                table.remove(scheduled, 1)()
+                plugin._active_ai_dialog.args.buttons[1][1].callback()
+                assert.are.equal(1001, cancelled_pid)
+                assert.is_nil(plugin._active_ai_dialog)
+                assert.is_nil(plugin._active_ai_cancel)
+            end)
+
+            UIManager.scheduleIn = old_schedule
+            if not ok then error(err) end
         end)
 
         it("handles invalid or non-table result in _processSingleWordResult without crashing", function()

--- a/xray.koplugin/main.lua
+++ b/xray.koplugin/main.lua
@@ -236,11 +236,12 @@ end
 function XRayPlugin:destroy()
     if self.destroyed then return end
     self:log("XRayPlugin: destroy called, marking as destroyed")
-    self.destroyed = true
-    
-    if self.ai_helper then
+    if self.cancelActiveAIRequest then
+        self:cancelActiveAIRequest("Plugin destroyed")
+    elseif self.ai_helper then
         self.ai_helper:cancelAsyncChild()
     end
+    self.destroyed = true
     
     if self.active_mention_scan and self.active_mention_scan.cancel_handle then
         self.active_mention_scan.cancel_handle:cancel()

--- a/xray.koplugin/main.lua
+++ b/xray.koplugin/main.lua
@@ -655,6 +655,14 @@ function XRayPlugin:triggerBackgroundMergeFetch(chapter_title)
             return
         end
 
+        -- Foreground requests own the single async child slot and its global
+        -- cancel handler. Do not consume the background cooldown or disturb
+        -- that ownership while one is active.
+        if self._active_ai_cancel or self.ai_helper._async_child_pid then
+            self:log("XRayPlugin: Skipping background fetch because another AI request is active")
+            return
+        end
+
         -- Cooldown check to prevent API spamming
         local cooldown = self.ai_helper.settings and self.ai_helper.settings.auto_fetch_cooldown or 300
         local now = os.time()

--- a/xray.koplugin/main.lua
+++ b/xray.koplugin/main.lua
@@ -288,8 +288,9 @@ function XRayPlugin:onExit()
     self:destroy()
 end
 
-
-
+function XRayPlugin:onSuspend()
+    self:cancelActiveAIRequest("Fetch cancelled because the device suspended")
+end
 
 -- Builds the X-Ray button spec for the dict popup.
 -- Used by both the new addToDictButtons API and the legacy onDictButtonsReady hook.
@@ -2643,4 +2644,3 @@ end
 -- Extracted functions are now loaded via mixins (xray_data, xray_ui, xray_fetch, xray_mentions)
 
 return XRayPlugin
-

--- a/xray.koplugin/xray_fetch.lua
+++ b/xray.koplugin/xray_fetch.lua
@@ -16,7 +16,7 @@ end
 local M = {}
 
 function M:isRequestTimedOut(started_at, timeout_seconds)
-    return os.time() - started_at >= timeout_seconds
+    return os.difftime(os.time(), started_at or os.time()) >= timeout_seconds
 end
 
 function M:cancelActiveAIRequest(reason)
@@ -148,12 +148,12 @@ function M:fetchSingleWord(text, pos0, pos1)
         -- Second tick: start the actual work. This two-step approach ensures the progress
         -- bar borders are fully committed to screen before the CPU starts blocking.
         UIManager:scheduleIn(0.3, function()
-            if self.destroyed or not self.ui or not self.ui.document then
+            if is_cancelled or self.destroyed or not self.ui or not self.ui.document then
                 if progress_msg then UIManager:close(progress_msg) end
                 return
             end
             UIManager:scheduleIn(0.3, function()
-            if self.destroyed or not self.ui or not self.ui.document then
+            if is_cancelled or self.destroyed or not self.ui or not self.ui.document then
                 if progress_msg then UIManager:close(progress_msg) end
                 return
             end
@@ -202,7 +202,7 @@ function M:fetchSingleWord(text, pos0, pos1)
                 end
             end)
 
-            if self.destroyed or not self.ui or not self.ui.document then
+            if is_cancelled or self.destroyed or not self.ui or not self.ui.document then
                 if progress_msg then UIManager:close(progress_msg) end
                 return
             end
@@ -271,9 +271,11 @@ function M:fetchSingleWord(text, pos0, pos1)
                             UIManager:close(progress_msg)
                             if self._active_ai_dialog == progress_msg then self._active_ai_dialog = nil end
                             if self._active_ai_cancel == cancelLookup then self._active_ai_cancel = nil end
-                            self:_processSingleWordResult(data, text, book_text, current_page)
+                            if not is_cancelled then
+                                self:_processSingleWordResult(data, text, book_text, current_page)
+                            end
                         end)
-                    else
+                    elseif not is_cancelled then
                         self:_processSingleWordResult(data, text, book_text, current_page)
                     end
                 end
@@ -477,6 +479,9 @@ function M:continueWithFetch(reading_percent, is_update, last_fetch_page, is_sil
         end
         if result_file then
             pcall(function() os.remove(result_file) end)
+        end
+        if wait_msg then
+            UIManager:close(wait_msg)
         end
         finishActiveRequest()
         self:log("XRayPlugin: " .. reason)

--- a/xray.koplugin/xray_fetch.lua
+++ b/xray.koplugin/xray_fetch.lua
@@ -21,8 +21,15 @@ end
 
 function M:cancelActiveAIRequest(reason)
     if self._active_ai_cancel then
-        self._active_ai_cancel(reason or "AI request cancelled")
-    elseif self.ai_helper and self.ai_helper._async_child_pid then
+        local ok, err = pcall(self._active_ai_cancel, reason or "AI request cancelled")
+        if not ok then
+            self:log("XRayPlugin: Active AI cancellation callback failed: " .. tostring(err))
+        end
+    end
+    -- The registered callback may be stale or may have failed before reaching
+    -- its owned child. A global lifecycle cancellation must not leave whatever
+    -- child the helper currently owns running.
+    if self.ai_helper and self.ai_helper._async_child_pid then
         self.ai_helper:cancelAsyncChild()
     end
     self._active_ai_cancel = nil
@@ -148,13 +155,15 @@ function M:fetchSingleWord(text, pos0, pos1)
         -- Second tick: start the actual work. This two-step approach ensures the progress
         -- bar borders are fully committed to screen before the CPU starts blocking.
         UIManager:scheduleIn(0.3, function()
-            if is_cancelled or self.destroyed or not self.ui or not self.ui.document then
-                if progress_msg then UIManager:close(progress_msg) end
+            if is_cancelled then return end
+            if self.destroyed or not self.ui or not self.ui.document then
+                cancelLookup("Single word lookup cancelled because the document or plugin is unavailable")
                 return
             end
             UIManager:scheduleIn(0.3, function()
-            if is_cancelled or self.destroyed or not self.ui or not self.ui.document then
-                if progress_msg then UIManager:close(progress_msg) end
+            if is_cancelled then return end
+            if self.destroyed or not self.ui or not self.ui.document then
+                cancelLookup("Single word lookup cancelled because the document or plugin is unavailable")
                 return
             end
             if not self.chapter_analyzer then self.chapter_analyzer = require(plugin_path .. "xray_chapteranalyzer"):new() end
@@ -202,8 +211,9 @@ function M:fetchSingleWord(text, pos0, pos1)
                 end
             end)
 
-            if is_cancelled or self.destroyed or not self.ui or not self.ui.document then
-                if progress_msg then UIManager:close(progress_msg) end
+            if is_cancelled then return end
+            if self.destroyed or not self.ui or not self.ui.document then
+                cancelLookup("Single word lookup cancelled because the document or plugin is unavailable")
                 return
             end
 
@@ -413,7 +423,13 @@ function M:continueWithFetch(reading_percent, is_update, last_fetch_page, is_sil
     local doc_file = self.ui.document.file
     if not doc_file then return end
 
-    if not is_silent and (self._active_ai_cancel or (self.ai_helper and self.ai_helper._async_child_pid)) then
+    local has_active_request = self._active_ai_cancel
+        or (self.ai_helper and self.ai_helper._async_child_pid)
+    if is_silent and has_active_request then
+        self.bg_fetch_pending = false
+        self:log("XRayPlugin: Skipping background fetch because another AI request is active")
+        return
+    elseif not is_silent and has_active_request then
         self:cancelActiveAIRequest("Previous AI request replaced by manual fetch")
     end
     self._fetch_generation = (self._fetch_generation or 0) + 1
@@ -500,8 +516,6 @@ function M:continueWithFetch(reading_percent, is_update, last_fetch_page, is_sil
             buttons = {{{
                 text = self.loc:t("cancel") or "Cancel",
                 callback = function()
-                    is_cancelled = true
-                    if wait_msg then UIManager:close(wait_msg) end
                     cancelActiveRequest("Fetch cancelled by user")
                 end
             }}}
@@ -683,7 +697,6 @@ function M:continueWithFetch(reading_percent, is_update, last_fetch_page, is_sil
                     if not self:isRequestTimedOut(request_started_at, request_timeout) then
                         UIManager:scheduleIn(2, poll)
                     else
-                        if wait_msg then UIManager:close(wait_msg) end
                         cancelActiveRequest("Fetch timed out")
                         if not is_silent then
                             local title, text = utils:getFriendlyError("error_timeout", nil, self.loc)

--- a/xray.koplugin/xray_fetch.lua
+++ b/xray.koplugin/xray_fetch.lua
@@ -15,6 +15,26 @@ end
 
 local M = {}
 
+function M:isRequestTimedOut(started_at, timeout_seconds)
+    return os.time() - started_at >= timeout_seconds
+end
+
+function M:cancelActiveAIRequest(reason)
+    if self._active_ai_cancel then
+        self._active_ai_cancel(reason or "AI request cancelled")
+    elseif self.ai_helper and self.ai_helper._async_child_pid then
+        self.ai_helper:cancelAsyncChild()
+    end
+    self._active_ai_cancel = nil
+    if self._active_ai_dialog then
+        UIManager:close(self._active_ai_dialog)
+        self._active_ai_dialog = nil
+    end
+    self._active_fetch_generation = nil
+    self.bg_fetch_active = false
+    self.bg_fetch_pending = false
+end
+
 local function sanitizeMetadata(val)
     if type(val) == "string" then return val
     elseif type(val) == "table" then return table.concat(val, ", ")
@@ -67,6 +87,10 @@ function M:fetchSingleWord(text, pos0, pos1)
 
     require("ui/network/manager"):runWhenOnline(function()
         if self.destroyed or not self.ui or not self.ui.document or not self.ui.getCurrentPage then return end
+
+        if self._active_ai_cancel or (self.ai_helper and self.ai_helper._async_child_pid) then
+            self:cancelActiveAIRequest("Previous AI request replaced by single word lookup")
+        end
         
         local current_page = self.ui:getCurrentPage()
         local total_pages = (type(self.ui.document.getPageCount) == "function" and self.ui.document:getPageCount()) or 1
@@ -90,14 +114,33 @@ function M:fetchSingleWord(text, pos0, pos1)
             return
         end
 
-        local ProgressBarDialog = require("ui/widget/progressbardialog")
-        local progress_msg = ProgressBarDialog:new{
+        local ButtonDialog = require("ui/widget/buttondialog")
+        local request_pid
+        local result_file
+        local is_cancelled = false
+        local progress_msg
+        local function cancelLookup(reason)
+            if is_cancelled then return end
+            is_cancelled = true
+            if request_pid and self.ai_helper and self.ai_helper.cancelAsyncChild then
+                self.ai_helper:cancelAsyncChild(request_pid)
+            end
+            if result_file then pcall(function() os.remove(result_file) end) end
+            if progress_msg then UIManager:close(progress_msg) end
+            if self._active_ai_dialog == progress_msg then self._active_ai_dialog = nil end
+            if self._active_ai_cancel == cancelLookup then self._active_ai_cancel = nil end
+            self:log("XRayPlugin: " .. (reason or "Single word lookup cancelled"))
+        end
+        progress_msg = ButtonDialog:new{
             title = self.loc:t("looking_up_msg", _truncateSafe(text, 30)),
-            text = text,
-            progress_max = 100,
-            dismissable = false,
-            refresh_time_seconds = 0.05,
+            text = text .. "\n\n" .. (self.loc:t("fetching_wait") or "This may take a moment.\nTap Cancel to stop."),
+            buttons = {{{
+                text = self.loc:t("cancel") or "Cancel",
+                callback = function() cancelLookup("Single word lookup cancelled by user") end,
+            }}},
         }
+        self._active_ai_dialog = progress_msg
+        self._active_ai_cancel = cancelLookup
         UIManager:show(progress_msg)
         UIManager:forceRePaint()
 
@@ -116,12 +159,8 @@ function M:fetchSingleWord(text, pos0, pos1)
             end
             if not self.chapter_analyzer then self.chapter_analyzer = require(plugin_path .. "xray_chapteranalyzer"):new() end
             
-            progress_msg:reportProgress(10)
-            
             -- 1. Distributed chapter samples (Start/Mid/End of each chapter up to current)
             local samples, chapter_titles = self.chapter_analyzer:getDetailedChapterSamples(self.ui, 100, 60000, limit_percent == 100, nil, nil, current_page)
-            
-            progress_msg:reportProgress(30)
             
             -- 2. Immediate book text (Previous and Current page for maximum context relevance)
             local end_page = self.chapter_analyzer:getEndPageForCurrentPage(self.ui, current_page)
@@ -138,8 +177,6 @@ function M:fetchSingleWord(text, pos0, pos1)
             end
             
             self:log("fetchSingleWord: extracted book_text length: " .. tostring(book_text and #book_text or 0))
-            
-            progress_msg:reportProgress(40)
             
             local context = {
                 reading_percent = limit_percent,
@@ -175,10 +212,12 @@ function M:fetchSingleWord(text, pos0, pos1)
                 self.ai_helper:cancelAsyncChild()
             end
 
-            local result_file = settings_xray_dir .. "/sw_fetch_" .. tostring(os.time()) .. ".json"
-            local request_pid = self.ai_helper:lookupSingleWordAsync(text, context, result_file)
+            result_file = settings_xray_dir .. "/sw_fetch_" .. tostring(os.time()) .. ".json"
+            request_pid = self.ai_helper:lookupSingleWordAsync(text, context, result_file)
             if not request_pid then
                 if progress_msg then UIManager:close(progress_msg) end
+                if self._active_ai_dialog == progress_msg then self._active_ai_dialog = nil end
+                if self._active_ai_cancel == cancelLookup then self._active_ai_cancel = nil end
                 self:log("XRayPlugin: Failed to start async lookup")
                 local ConfirmBox = require("ui/widget/confirmbox")
                 local title, text_msg = utils:getFriendlyError("error_api", "Failed to start background process", self.loc)
@@ -189,42 +228,25 @@ function M:fetchSingleWord(text, pos0, pos1)
                 return
             end
 
-            progress_msg:reportProgress(50)
-
-            local poll_count = 0
-            local max_polls = 150 -- 5 minutes at 2s intervals
-            local current_progress = 50
+            local request_started_at = os.time()
+            local request_timeout = 300
             local function poll()
+                if is_cancelled then return end
                 if self.destroyed or not self.ui or not self.ui.document then
-                    if progress_msg then UIManager:close(progress_msg) end
-                    if self.ai_helper and self.ai_helper.cancelAsyncChild then
-                        self.ai_helper:cancelAsyncChild(request_pid)
-                    end
-                    pcall(function() os.remove(result_file) end)
-                    self:log("XRayPlugin: Single word lookup cancelled or document/plugin unavailable")
+                    cancelLookup("Single word lookup cancelled because the document or plugin is unavailable")
                     return
                 end
-                
-                -- Simulate gradual progress while waiting for AI
-                if current_progress < 95 then
-                    current_progress = current_progress + 5
-                    if progress_msg then 
-                        progress_msg:reportProgress(current_progress)
-                    end
-                end
-                
-                poll_count = poll_count + 1
+
                 if not self.ai_helper or not self.ai_helper.checkAsyncResult then
-                    if progress_msg then UIManager:close(progress_msg) end
+                    cancelLookup("Single word lookup stopped because the AI helper is unavailable")
                     return
                 end
                 local data, p_err_code, p_err_msg = self.ai_helper:checkAsyncResult(result_file, request_pid)
                 if data == nil then
-                    if poll_count < max_polls then
+                    if not self:isRequestTimedOut(request_started_at, request_timeout) then
                         UIManager:scheduleIn(2, poll)
                     else
-                        if progress_msg then UIManager:close(progress_msg) end
-                        self:log("XRayPlugin: Single word lookup timed out")
+                        cancelLookup("Single word lookup timed out")
                         local ConfirmBox = require("ui/widget/confirmbox")
                         local title, text_msg = utils:getFriendlyError("error_timeout", nil, self.loc)
                         UIManager:show(ConfirmBox:new{                            text = title .. "\n\n" .. text_msg,
@@ -234,6 +256,8 @@ function M:fetchSingleWord(text, pos0, pos1)
                     end
                 elseif data == false then
                     if progress_msg then UIManager:close(progress_msg) end
+                    if self._active_ai_dialog == progress_msg then self._active_ai_dialog = nil end
+                    if self._active_ai_cancel == cancelLookup then self._active_ai_cancel = nil end
                     self:log("XRayPlugin: Single word lookup failed: " .. tostring(p_err_msg))
                     local ConfirmBox = require("ui/widget/confirmbox")
                     local title, text_msg = utils:getFriendlyError(p_err_code, p_err_msg, self.loc)
@@ -243,9 +267,10 @@ function M:fetchSingleWord(text, pos0, pos1)
                     })
                 else
                     if progress_msg then
-                        progress_msg:reportProgress(100)
                         UIManager:scheduleIn(0.1, function()
                             UIManager:close(progress_msg)
+                            if self._active_ai_dialog == progress_msg then self._active_ai_dialog = nil end
+                            if self._active_ai_cancel == cancelLookup then self._active_ai_cancel = nil end
                             self:_processSingleWordResult(data, text, book_text, current_page)
                         end)
                     else
@@ -386,6 +411,9 @@ function M:continueWithFetch(reading_percent, is_update, last_fetch_page, is_sil
     local doc_file = self.ui.document.file
     if not doc_file then return end
 
+    if not is_silent and (self._active_ai_cancel or (self.ai_helper and self.ai_helper._async_child_pid)) then
+        self:cancelActiveAIRequest("Previous AI request replaced by manual fetch")
+    end
     self._fetch_generation = (self._fetch_generation or 0) + 1
     local fetch_generation = self._fetch_generation
     self._active_fetch_generation = fetch_generation
@@ -432,14 +460,18 @@ function M:continueWithFetch(reading_percent, is_update, last_fetch_page, is_sil
     local is_cancelled = false
     local result_file
     local request_pid
+    local cancelActiveRequest
 
     local function finishActiveRequest()
         request_pid = nil
         result_file = nil
         clearFetchState()
+        if self._active_ai_dialog == wait_msg then self._active_ai_dialog = nil end
+        if self._active_ai_cancel == cancelActiveRequest then self._active_ai_cancel = nil end
     end
 
-    local function cancelActiveRequest(reason)
+    cancelActiveRequest = function(reason)
+        is_cancelled = true
         if request_pid and self.ai_helper and self.ai_helper.cancelAsyncChild then
             self.ai_helper:cancelAsyncChild(request_pid)
         end
@@ -449,6 +481,8 @@ function M:continueWithFetch(reading_percent, is_update, last_fetch_page, is_sil
         finishActiveRequest()
         self:log("XRayPlugin: " .. reason)
     end
+
+    self._active_ai_cancel = cancelActiveRequest
 
     if not is_silent then
         local ButtonDialog = require("ui/widget/buttondialog")
@@ -467,11 +501,18 @@ function M:continueWithFetch(reading_percent, is_update, last_fetch_page, is_sil
                 end
             }}}
         }
+        self._active_ai_dialog = wait_msg
         UIManager:show(wait_msg)
     end
 
     UIManager:scheduleIn(0.5, function()
-        if is_cancelled or self.destroyed or not self.ui or not self.ui.document then clearFetchState(); return end
+        if is_cancelled then return end
+        if self.destroyed or not self.ui or not self.ui.document then
+            cancelActiveRequest(self.destroyed
+                and "Fetch stopped because plugin was destroyed"
+                or "Fetch stopped because the document was closed")
+            return
+        end
         if not self.chapter_analyzer then self.chapter_analyzer = require(plugin_path .. "xray_chapteranalyzer"):new() end
 
         local current_page = self.ui:getCurrentPage()
@@ -519,8 +560,14 @@ function M:continueWithFetch(reading_percent, is_update, last_fetch_page, is_sil
         end
 
         UIManager:scheduleIn(0, function()
-            if is_cancelled or self.destroyed then clearFetchState(); return end
-            if not self.ui or not self.ui.document then clearFetchState(); return end
+            if is_cancelled or self.destroyed then
+                if not is_cancelled then cancelActiveRequest("Fetch stopped because plugin was destroyed") end
+                return
+            end
+            if not self.ui or not self.ui.document then
+                cancelActiveRequest("Fetch stopped because the document was closed")
+                return
+            end
 
             -- A cached page can outlive pagination changes or be ahead of the
             -- reader's current position. In that case an incremental XPointer
@@ -547,7 +594,7 @@ function M:continueWithFetch(reading_percent, is_update, last_fetch_page, is_sil
                 end
                 if not is_silent then UIManager:show(InfoMessage:new{ text = message, timeout = 5 }) end
                 self:log("XRayPlugin: Text extraction failed" .. (is_silent and " (silent)" or ""))
-                clearFetchState()
+                finishActiveRequest()
                 return
             end
 
@@ -570,7 +617,7 @@ function M:continueWithFetch(reading_percent, is_update, last_fetch_page, is_sil
             if not req_params then
                 if wait_msg then UIManager:close(wait_msg) end
                 self:log("XRayPlugin: Failed to build request: " .. tostring(err_msg))
-                clearFetchState()
+                finishActiveRequest()
                 if not is_silent then
                     if not self.ai_helper:hasApiKey() and self.showWelcomeCard then
                         self:showWelcomeCard()
@@ -610,13 +657,13 @@ function M:continueWithFetch(reading_percent, is_update, last_fetch_page, is_sil
                 self:log("XRayPlugin: Failed to start async fetch")
                 pcall(function() os.remove(result_file) end)
                 result_file = nil
-                clearFetchState()
+                finishActiveRequest()
                 return
             end
             request_pid = started
 
-            local poll_count = 0
-            local max_polls = 300 -- 10 minutes at 2s intervals
+            local request_started_at = os.time()
+            local request_timeout = 600
             local function poll()
                 if is_cancelled or self.destroyed then
                     cancelActiveRequest(self.destroyed and "Fetch stopped because plugin was destroyed" or "Fetch cancelled")
@@ -626,10 +673,9 @@ function M:continueWithFetch(reading_percent, is_update, last_fetch_page, is_sil
                     cancelActiveRequest("Fetch stopped because the document was closed")
                     return
                 end
-                poll_count = poll_count + 1
                 local data, p_err_code, p_err_msg = self.ai_helper:checkAsyncResult(result_file, request_pid)
                 if data == nil then
-                    if poll_count < max_polls then
+                    if not self:isRequestTimedOut(request_started_at, request_timeout) then
                         UIManager:scheduleIn(2, poll)
                     else
                         if wait_msg then UIManager:close(wait_msg) end


### PR DESCRIPTION
I ran into a hang issue when using inline lookups. A request stalled after a temporary Gemini error, and the only way out was to restart the entire kindle.

PR #94 already added solid support for terminating active request processes, so this builds on that work. The missing pieces were cancelling requests when the Kindle suspends, using real elapsed time for timeouts, and making inline lookups cancellable from the UI.


## Summary

- Add a real Cancel button to inline/single-word AI lookups.
- Cancel active AI work when the device suspends.
- Replace a stuck background request when a manual fetch or lookup starts.
- Enforce lookup and fetch deadlines using elapsed wall time instead of poll counts.
- Clear dialogs, temporary files, and fetch state through the existing PR #94 cancellation engine.

## Why

A Kindle log captured this sequence:

- An automatic Gemini fetch started and received a 503.
- The Kindle suspended while the retry was active.
- UI polling paused during suspend, so the poll-count timeout did not advance.
- After resume, the old PID still blocked later manual fetches.
- The request was only collected roughly 49 minutes later.

PR #94 provides reliable PID ownership, process-group termination, and child reaping. This change adds the missing suspend, replacement, timeout, and inline-popup triggers.

## Testing

- Added coverage for wall-clock deadlines.
- Added coverage for registered and orphan request cleanup.
- Added coverage verifying that the inline Cancel button terminates its owned PID.
- LuaJIT bytecode compilation succeeds for the changed runtime files.
- Kindle smoke test: patched files installed on a Paperwhite 5 for cancellation and suspend testing.

The local all-spec runner reports 258 passing tests and 27 existing AI-helper/config failures unrelated to these files.
