### PR TITLE
Timeline: scrolling view, presence map, sort and jump controls

### DIFF
--- a/spec/xray_presencemap_spec.lua
+++ b/spec/xray_presencemap_spec.lua
@@ -1,0 +1,299 @@
+-- xray_presencemap_spec.lua
+require("spec.spec_helper")
+local presence = require("xray_presencemap")
+
+describe("xray_presencemap", function()
+
+    describe("buildPresenceMatrix", function()
+
+        it("marks a character present in a chapter that names them", function()
+            local timeline = {
+                { chapter = "Chapter 1", event = "Victor recounts his childhood." },
+            }
+            local characters = {
+                { name = "Victor Frankenstein", aliases = { "Victor" } },
+            }
+            local matrix = presence.buildPresenceMatrix(timeline, characters)
+            assert.is_true(matrix[1]["Victor Frankenstein"])
+        end)
+
+        it("does not match a name that is only a substring of another word", function()
+            local timeline = {
+                { chapter = "Chapter 7", event = "William is dead." },
+            }
+            local characters = { { name = "Will", aliases = {} } }
+            local matrix = presence.buildPresenceMatrix(timeline, characters)
+            assert.is_nil(matrix[1]["Will"])
+        end)
+
+        it("counts a character named in the chapter title but not the event text", function()
+            local timeline = {
+                { chapter = "Walton's Letter", event = "The voyage north begins." },
+            }
+            local characters = { { name = "Walton", aliases = {} } }
+            local matrix = presence.buildPresenceMatrix(timeline, characters)
+            assert.is_true(matrix[1]["Walton"])
+        end)
+
+        it("builds one row per event it is given, in order", function()
+            -- Filtering out prior-book events is the caller's job, so the row
+            -- index always lines up with the caller's own event list.
+            local timeline = {
+                { chapter = "Chapter 1", event = "Victor begins." },
+                { chapter = "Chapter 2", event = "Nobody in particular." },
+                { chapter = "Chapter 3", event = "Victor returns." },
+            }
+            local characters = { { name = "Victor", aliases = {} } }
+            local matrix = presence.buildPresenceMatrix(timeline, characters)
+            assert.equals(3, #matrix)
+            assert.is_true(matrix[1]["Victor"])
+            assert.is_nil(matrix[2]["Victor"])
+            assert.is_true(matrix[3]["Victor"])
+        end)
+
+        it("skips a character with no name rather than crashing", function()
+            -- The AI can return an entry with aliases and no name; deduplication
+            -- keeps it. Indexing the result table by a nil name would error.
+            local timeline = { { chapter = "Chapter 1", event = "Victor walks." } }
+            local characters = { { aliases = { "Victor" } }, { name = "Victor" } }
+            local matrix = presence.buildPresenceMatrix(timeline, characters)
+            assert.is_true(matrix[1]["Victor"])
+        end)
+
+        it("matches regardless of letter case", function()
+            -- The plugin's other matchers are case-insensitive; a presence map
+            -- that disagreed with Mentions about the same chapter would be worse
+            -- than one that is slightly generous.
+            local timeline = { { chapter = "Chapter 1", event = "the creature stirs." } }
+            local characters = { { name = "The Creature", aliases = {} } }
+            local matrix = presence.buildPresenceMatrix(timeline, characters)
+            assert.is_true(matrix[1]["The Creature"])
+        end)
+
+    end)
+
+    describe("coverageOrder", function()
+
+        -- Victor in 3 chapters, Creature in 2, Walton in 1.
+        local function sampleMatrix()
+            return {
+                [1] = { Victor = true },
+                [2] = { Victor = true, Creature = true },
+                [3] = { Victor = true, Creature = true, Walton = true },
+            }
+        end
+        local sampleChars = {
+            { name = "Walton" }, { name = "Creature" }, { name = "Victor" },
+        }
+
+        it("orders characters by how many chapters name each of them", function()
+            assert.same({ "Victor", "Creature", "Walton" },
+                        presence.coverageOrder(sampleMatrix(), sampleChars))
+        end)
+
+        it("drops characters who appear in no chapter", function()
+            local chars = { { name = "Victor" }, { name = "Ghost" } }
+            assert.same({ "Victor" },
+                        presence.coverageOrder({ [1] = { Victor = true } }, chars))
+        end)
+
+        it("breaks equal coverage by earliest appearance, then by name", function()
+            -- Ernest and Justine both have coverage 1; Justine appears first.
+            local matrix = { [1] = { Justine = true }, [2] = { Ernest = true } }
+            local chars = { { name = "Ernest" }, { name = "Justine" } }
+            assert.same({ "Justine", "Ernest" }, presence.coverageOrder(matrix, chars))
+        end)
+
+    end)
+
+    describe("matchingChapters", function()
+
+        -- Victor 1-3, Creature 2-3, Walton 3 only.
+        local matrix = {
+            [1] = { Victor = true },
+            [2] = { Victor = true, Creature = true },
+            [3] = { Victor = true, Creature = true, Walton = true },
+        }
+
+        it("returns every chapter when nothing is selected", function()
+            assert.same({ 1, 2, 3 }, presence.matchingChapters(matrix, {}))
+        end)
+
+        it("returns the chapters holding a single selected character", function()
+            assert.same({ 2, 3 }, presence.matchingChapters(matrix, { "Creature" }))
+        end)
+
+        it("returns only chapters holding every selected character", function()
+            assert.same({ 3 }, presence.matchingChapters(matrix, { "Creature", "Walton" }))
+        end)
+
+        it("returns nothing when the selected characters never share a chapter", function()
+            local apart = { [1] = { Ann = true }, [2] = { Bob = true } }
+            assert.same({}, presence.matchingChapters(apart, { "Ann", "Bob" }))
+        end)
+
+    end)
+
+
+    describe("split strip (frozen names, scrollable grid)", function()
+
+        local GEOM = {
+            name_width = 78, col_width = 26, row_height = 19,
+            top_padding = 6, marker = 9, label_size = 8,
+        }
+        local matrix = {
+            [1] = { Victor = true },
+            [2] = { Victor = true, Creature = true },
+            [3] = { Victor = true, Creature = true, Walton = true },
+        }
+        local chapters = { "Letter 1", "Chapter 1", "Chapter 2" }
+        local order = { "Victor", "Creature", "Walton" }
+
+        local function count(svg, class)
+            local n = 0
+            for _ in svg:gmatch('class="' .. class .. '"') do n = n + 1 end
+            return n
+        end
+
+        describe("buildStripNamesSVG", function()
+
+            it("is exactly the name gutter wide", function()
+                local _, w = presence.buildStripNamesSVG(order, {}, GEOM)
+                assert.equals(GEOM.name_width, w)
+            end)
+
+            it("writes every name when nothing is selected", function()
+                local svg = presence.buildStripNamesSVG(order, {}, GEOM)
+                for _, n in ipairs(order) do
+                    assert.is_not_nil(svg:find(">" .. n .. "<", 1, true))
+                end
+            end)
+
+            it("writes only the selected names when filtering", function()
+                local svg = presence.buildStripNamesSVG(order, { "Victor" }, GEOM)
+                assert.is_not_nil(svg:find(">Victor<", 1, true))
+                assert.is_nil(svg:find(">Walton<", 1, true))
+            end)
+
+        end)
+
+        describe("buildStripGridSVG", function()
+
+            it("is exactly the columns wide, with no name gutter", function()
+                local _, w = presence.buildStripGridSVG(matrix, order, chapters, {}, GEOM,
+                    presence.matchingChapters(matrix, {}))
+                assert.equals(#chapters * GEOM.col_width, w)
+            end)
+
+            it("keeps its own height in step with the names", function()
+                local _, _, gh = presence.buildStripGridSVG(matrix, order, chapters, {}, GEOM,
+                    presence.matchingChapters(matrix, {}))
+                local _, _, nh = presence.buildStripNamesSVG(order, {}, GEOM)
+                assert.equals(nh, gh)
+            end)
+
+            it("draws a marker for every appearance", function()
+                local svg = presence.buildStripGridSVG(matrix, order, chapters, {}, GEOM,
+                    presence.matchingChapters(matrix, {}))
+                assert.equals(6, count(svg, "pip"))
+            end)
+
+            it("shades and joins the columns holding all selected characters", function()
+                local svg = presence.buildStripGridSVG(matrix, order, chapters, { "Creature", "Walton" }, GEOM,
+                    presence.matchingChapters(matrix, { "Creature", "Walton" }))
+                assert.equals(1, count(svg, "shade"))
+                assert.equals(1, count(svg, "join"))
+            end)
+
+            it("uses caller-supplied matches when given", function()
+                -- Bucketed crossings are worked out per chapter, so the renderer
+                -- must be told which columns matched rather than deriving them.
+                local svg = presence.buildStripGridSVG(matrix, order, chapters,
+                    { "Victor", "Creature" }, GEOM, { 1 })
+                assert.equals(1, count(svg, "shade"))
+                -- column 1 is the shaded one, not column 3 as derivation would give
+                local x = tonumber(svg:match('class="shade" x="([%-%d%.]+)"'))
+                assert.is_true(x < GEOM.col_width)
+            end)
+
+            it("draws no join for a single selected character", function()
+                local svg = presence.buildStripGridSVG(matrix, order, chapters, { "Victor" }, GEOM,
+                    presence.matchingChapters(matrix, { "Victor" }))
+                assert.equals(0, count(svg, "join"))
+            end)
+
+            it("places the first column at the very left edge", function()
+                -- No name gutter, so the grid can be scrolled independently.
+                local svg = presence.buildStripGridSVG(matrix, order, chapters, {}, GEOM,
+                    presence.matchingChapters(matrix, {}))
+                local first_x = tonumber(svg:match('class="pip" x="([%d%.]+)"'))
+                assert.is_true(first_x < GEOM.col_width)
+            end)
+
+        end)
+    end)
+
+    describe("bucketMatrix", function()
+
+        -- 9 chapters. Ann is in 1 and 5; Bob is in 3 and 5. They share only 5.
+        local matrix = {}
+        for i = 1, 9 do matrix[i] = {} end
+        matrix[1].Ann = true
+        matrix[3].Bob = true
+        matrix[5].Ann = true
+        matrix[5].Bob = true
+
+        it("collapses chapters into the requested number of columns", function()
+            local buckets = presence.bucketMatrix(matrix, {}, 3)
+            assert.equals(3, #buckets)
+        end)
+
+        it("covers every chapter across the ranges, with no gap or overlap", function()
+            local _, _, ranges = presence.bucketMatrix(matrix, {}, 3)
+            assert.equals(1, ranges[1].first)
+            assert.equals(9, ranges[#ranges].last)
+            for i = 2, #ranges do
+                assert.equals(ranges[i - 1].last + 1, ranges[i].first)
+            end
+        end)
+
+        it("marks a character present if they appear anywhere in the span", function()
+            -- span 1 covers chapters 1-3, and Ann is in chapter 1
+            local buckets = presence.bucketMatrix(matrix, {}, 3)
+            assert.is_true(buckets[1].Ann)
+        end)
+
+        it("leaves a span empty for a character who never appears in it", function()
+            -- span 3 covers chapters 7-9, where nobody appears
+            local buckets = presence.bucketMatrix(matrix, {}, 3)
+            assert.is_nil(buckets[3].Ann)
+        end)
+
+        it("reports a crossing only where the characters share one chapter", function()
+            -- span 2 covers 4-6 and both are in chapter 5
+            local _, matches = presence.bucketMatrix(matrix, presence.matchingChapters(matrix, { "Ann", "Bob" }), 3)
+            assert.same({ 2 }, matches)
+        end)
+
+        it("does not report a crossing when they merely fall in the same span", function()
+            -- Chapters 1-3 hold Ann (1) and Bob (3): both present in span 1, but
+            -- never in the same chapter. Bucketing presence first would say they met.
+            local apart = {}
+            for i = 1, 9 do apart[i] = {} end
+            apart[1].Ann = true
+            apart[3].Bob = true
+            local buckets, matches = presence.bucketMatrix(apart, presence.matchingChapters(apart, { "Ann", "Bob" }), 3)
+            assert.is_true(buckets[1].Ann)
+            assert.is_true(buckets[1].Bob)
+            assert.same({}, matches)
+        end)
+
+        it("passes a short book through one chapter per column", function()
+            local buckets, _, ranges = presence.bucketMatrix(matrix, {}, 20)
+            assert.equals(9, #buckets)
+            assert.equals(1, ranges[1].first)
+            assert.equals(1, ranges[1].last)
+        end)
+
+    end)
+end)

--- a/spec/xray_presencemap_spec.lua
+++ b/spec/xray_presencemap_spec.lua
@@ -60,6 +60,16 @@ describe("xray_presencemap", function()
             assert.is_true(matrix[1]["Victor"])
         end)
 
+        it("still matches when an alias repeats the name", function()
+            -- The AI often lists the canonical name among the aliases. The
+            -- duplicate needle is dropped, so the match must come from the one
+            -- that is kept.
+            local timeline = { { chapter = "Chapter 1", event = "Victor walks." } }
+            local characters = { { name = "Victor", aliases = { "Victor", "victor" } } }
+            local matrix = presence.buildPresenceMatrix(timeline, characters)
+            assert.is_true(matrix[1]["Victor"])
+        end)
+
         it("matches regardless of letter case", function()
             -- The plugin's other matchers are case-insensitive; a presence map
             -- that disagreed with Mentions about the same chapter would be worse
@@ -68,6 +78,37 @@ describe("xray_presencemap", function()
             local characters = { { name = "The Creature", aliases = {} } }
             local matrix = presence.buildPresenceMatrix(timeline, characters)
             assert.is_true(matrix[1]["The Creature"])
+        end)
+
+        it("matches a character by surname when the text omits the first name", function()
+            -- Prose says "Holden's crew", never "James Holden", and the AI's
+            -- alias list does not always include the surname.
+            local timeline = { { chapter = "Chapter 1", event = "Holden and the crew agree." } }
+            local characters = { { name = "James Holden", aliases = { "Jim" } } }
+            local matrix = presence.buildPresenceMatrix(timeline, characters)
+            assert.is_true(matrix[1]["James Holden"])
+        end)
+
+        it("does not use a surname two characters share", function()
+            -- A surname both siblings answer to identifies neither. Guessing
+            -- would put one in every chapter that names the other.
+            local timeline = { { chapter = "Chapter 1", event = "Holden waited." } }
+            local characters = {
+                { name = "James Holden", aliases = {} },
+                { name = "Elise Holden", aliases = {} },
+            }
+            local matrix = presence.buildPresenceMatrix(timeline, characters)
+            assert.is_nil(matrix[1]["James Holden"])
+            assert.is_nil(matrix[1]["Elise Holden"])
+        end)
+
+        it("does not treat a short surname as a needle", function()
+            -- "Poe" would fire on "poem"; the boundary check saves that one, but
+            -- short surnames collide too readily to be worth guessing.
+            local timeline = { { chapter = "Chapter 1", event = "Roe waited." } }
+            local characters = { { name = "Alan Roe", aliases = {} } }
+            local matrix = presence.buildPresenceMatrix(timeline, characters)
+            assert.is_nil(matrix[1]["Alan Roe"])
         end)
 
     end)
@@ -132,6 +173,66 @@ describe("xray_presencemap", function()
             }
             local chars = { { name = "Ann" }, { name = "Bob" }, { name = "Cal" } }
             assert.same({ "Ann", "Bob", "Cal" }, presence.coverageOrder(matrix, chars, 2))
+        end)
+
+        it("skips a nameless character rather than ranking them", function()
+            -- buildPresenceMatrix tolerates a nameless AI entry, so this must
+            -- too. Such an entry has no matrix key and so no coverage; it must
+            -- not reach the sort, where it would be compared by name.
+            local matrix = { [1] = { Victor = true } }
+            local chars = { { aliases = { "Victor" } }, { name = "Victor" } }
+            assert.same({ "Victor" }, presence.coverageOrder(matrix, chars))
+        end)
+
+        it("keeps a lead when only the second entry for that name carries the role", function()
+            -- Two entries can share a name, and the role sits on whichever one
+            -- the AI wrote it on. Reading only the first would drop a
+            -- protagonist the minimum-coverage rule is meant to keep.
+            local matrix = {
+                [1] = { Lead = true, Ann = true, Bob = true, Cal = true },
+                [2] = { Ann = true, Bob = true, Cal = true },
+                [3] = { Ann = true, Bob = true, Cal = true },
+            }
+            local chars = {
+                { name = "Lead" }, { name = "Lead", role = "Protagonist" },
+                { name = "Ann" }, { name = "Bob" }, { name = "Cal" },
+            }
+            assert.same({ "Ann", "Bob", "Cal", "Lead" },
+                        presence.coverageOrder(matrix, chars, 2))
+        end)
+
+        it("gives one row to a name held by two character entries", function()
+            -- The matrix is keyed by name, so duplicates share a single key.
+            -- Listing the name twice would draw two identical rows against one
+            -- set of markers.
+            local matrix = { [1] = { Victor = true } }
+            local chars = { { name = "Victor" }, { name = "Victor" } }
+            assert.same({ "Victor" }, presence.coverageOrder(matrix, chars))
+        end)
+
+        it("ignores a matrix key with no character behind it", function()
+            -- Only the characters handed in get a row, so a stale key cannot
+            -- add one the name gutter would not draw.
+            local matrix = { [1] = { Victor = true, Stranger = true } }
+            assert.same({ "Victor" }, presence.coverageOrder(matrix, { { name = "Victor" } }))
+        end)
+
+        it("keeps a protagonist below the minimum coverage", function()
+            -- A lead who happens to appear in one chapter of what has been
+            -- fetched so far is not a walk-on.
+            -- Three others clear the minimum, so the MIN_FILTERED_ROWS floor
+            -- does not fire and the lead is kept by the role rule alone.
+            local matrix = {
+                [1] = { Lead = true, Ann = true, Bob = true, Cal = true },
+                [2] = { Ann = true, Bob = true, Cal = true },
+                [3] = { Ann = true, Bob = true, Cal = true },
+            }
+            local chars = {
+                { name = "Lead", role = "Protagonist" },
+                { name = "Ann" }, { name = "Bob" }, { name = "Cal" },
+            }
+            assert.same({ "Ann", "Bob", "Cal", "Lead" },
+                        presence.coverageOrder(matrix, chars, 2))
         end)
 
     end)
@@ -316,6 +417,16 @@ describe("xray_presencemap", function()
             assert.is_true(buckets[1].Ann)
             assert.is_true(buckets[1].Bob)
             assert.same({}, matches)
+        end)
+
+        it("returns no columns at all for a book with no chapters", function()
+            -- A timeline holding only prior-book events leaves an empty matrix.
+            -- The column count is floored at one, which would otherwise hand
+            -- back a bucket spanning a chapter that does not exist.
+            local buckets, matches, ranges = presence.bucketMatrix({}, {}, 5)
+            assert.same({}, buckets)
+            assert.same({}, matches)
+            assert.same({}, ranges)
         end)
 
         it("passes a short book through one chapter per column", function()

--- a/spec/xray_presencemap_spec.lua
+++ b/spec/xray_presencemap_spec.lua
@@ -104,6 +104,36 @@ describe("xray_presencemap", function()
             assert.same({ "Justine", "Ernest" }, presence.coverageOrder(matrix, chars))
         end)
 
+        it("keeps everyone with any coverage when no minimum is given", function()
+            -- Walton appears once and must survive the default call.
+            assert.same({ "Victor", "Creature", "Walton" },
+                        presence.coverageOrder(sampleMatrix(), sampleChars))
+        end)
+
+        it("drops characters below the minimum coverage", function()
+            -- Four characters, three of them in two or more chapters.
+            local matrix = {
+                [1] = { Ann = true, Bob = true, Cal = true },
+                [2] = { Ann = true, Bob = true, Cal = true },
+                [3] = { Ann = true, Dot = true },
+            }
+            local chars = { { name = "Ann" }, { name = "Bob" }, { name = "Cal" }, { name = "Dot" } }
+            assert.same({ "Ann", "Bob", "Cal" }, presence.coverageOrder(matrix, chars, 2))
+        end)
+
+        it("ignores the minimum when too few characters would survive it", function()
+            -- Only Ann clears a minimum of 2. Filtering to one row would leave a
+            -- book early in its reading with an almost empty map, so the whole
+            -- order is kept instead.
+            local matrix = {
+                [1] = { Ann = true },
+                [2] = { Ann = true, Bob = true },
+                [3] = { Cal = true },
+            }
+            local chars = { { name = "Ann" }, { name = "Bob" }, { name = "Cal" } }
+            assert.same({ "Ann", "Bob", "Cal" }, presence.coverageOrder(matrix, chars, 2))
+        end)
+
     end)
 
     describe("matchingChapters", function()

--- a/spec/xray_ui_spec.lua
+++ b/spec/xray_ui_spec.lua
@@ -471,6 +471,33 @@ describe("xray_ui", function()
         end)
     end)
 
+    describe("settingEnabled", function()
+        it("should return the default when the AI helper is missing", function()
+            -- The menu can be rendered while the plugin is still initialising.
+            -- KOReader calls checked_func without a pcall, so one error here
+            -- aborts the whole submenu and every checkmark disappears.
+            plugin.ai_helper = nil
+            assert.is_true(plugin:settingEnabled("unit_cat_length", true))
+            assert.is_false(plugin:settingEnabled("series_context_enabled", false))
+        end)
+
+        it("should return the default when settings are missing", function()
+            plugin.ai_helper = {}
+            assert.is_true(plugin:settingEnabled("unit_cat_length", true))
+            assert.is_false(plugin:settingEnabled("series_context_enabled", false))
+        end)
+
+        it("should return the stored value in preference to the default", function()
+            plugin.ai_helper.settings.series_context_enabled = true
+            assert.is_true(plugin:settingEnabled("series_context_enabled", false))
+        end)
+
+        it("should honour a stored false against a true default", function()
+            plugin.ai_helper.settings.unit_cat_length = false
+            assert.is_false(plugin:settingEnabled("unit_cat_length", true))
+        end)
+    end)
+
     describe("clearCache and clearSeriesCache", function()
         it("should reset all in-memory tables and flags on clearCache", function()
             plugin.characters = { { name = "Vin" } }

--- a/spec/xray_ui_spec.lua
+++ b/spec/xray_ui_spec.lua
@@ -1352,6 +1352,61 @@ describe("xray_ui", function()
             assert.are.equal("InputContainer", last.type)
         end)
     end)
+
+    describe("timelinePriorSpecs", function()
+
+        -- One consolidated recap per earlier book in the series, as
+        -- mergeSeriesContext builds them.
+        local function priors()
+            return {
+                { chapter = "[Book 1: The Fellowship of the Ring]",
+                  event = "Frodo inherits the Ring.", source = "series_prior", source_book = 1 },
+                { chapter = "[Book 2: The Two Towers]",
+                  event = "The Fellowship breaks.", source = "series_prior", source_book = 2 },
+            }
+        end
+
+        it("should give one row per prior book, in the order supplied", function()
+            local specs = plugin:timelinePriorSpecs(priors(), {})
+            assert.are.equal(2, #specs)
+            assert.are.equal("[Book 1: The Fellowship of the Ring]", specs[1].chapter)
+            assert.are.equal("[Book 2: The Two Towers]", specs[2].chapter)
+        end)
+
+        it("should carry the recap text so the row can preview it", function()
+            local specs = plugin:timelinePriorSpecs(priors(), {})
+            assert.are.equal("Frodo inherits the Ring.", specs[1].event)
+        end)
+
+        it("should flatten the recap's paragraph breaks for the preview", function()
+            -- The recap joins a book's events with blank lines. Left alone they
+            -- spend one of the preview's two lines on whitespace.
+            local given = { { chapter = "[Book 1: X]", event = "First thing.\n\nSecond thing.",
+                              source = "series_prior", source_book = 1 } }
+            local specs = plugin:timelinePriorSpecs(given, {})
+            assert.are.equal("First thing. Second thing.", specs[1].event)
+            -- Only the preview copy is flattened; the popup reads the original.
+            assert.are.equal("First thing.\n\nSecond thing.", specs[1].ev.event)
+        end)
+
+        it("should carry the event itself so tapping opens its details", function()
+            local given = priors()
+            local specs = plugin:timelinePriorSpecs(given, {})
+            assert.are.equal(given[1], specs[1].ev)
+        end)
+
+        it("should return nil when the book has no prior-book entries", function()
+            assert.is_nil(plugin:timelinePriorSpecs({}, {}))
+            assert.is_nil(plugin:timelinePriorSpecs(nil, {}))
+        end)
+
+        it("should return nil while a character filter is active", function()
+            -- Prior events are not in the presence matrix, so they cannot match
+            -- a character. Showing them under a filter would imply they had.
+            assert.is_nil(plugin:timelinePriorSpecs(priors(), { "Frodo" }))
+        end)
+
+    end)
 end)
 
 

--- a/spec/xray_ui_spec.lua
+++ b/spec/xray_ui_spec.lua
@@ -1353,6 +1353,44 @@ describe("xray_ui", function()
         end)
     end)
 
+    describe("timelineRowSpecs", function()
+
+        local function specs()
+            return {
+                { chapter = "Ch 1", event = "Victor begins." },
+                { chapter = "Ch 2", event = "The creature wakes." },
+                { chapter = "Ch 3", event = "Victor pursues." },
+            }
+        end
+
+        it("keeps book order when ascending", function()
+            local out = plugin:timelineRowSpecs(specs(), false)
+            assert.are.equal("Ch 1", out[1].chapter)
+            assert.are.equal("Ch 3", out[3].chapter)
+        end)
+
+        it("reverses the chapters when descending", function()
+            local out = plugin:timelineRowSpecs(specs(), true)
+            assert.are.equal("Ch 3", out[1].chapter)
+            assert.are.equal("Ch 1", out[3].chapter)
+        end)
+
+        it("does not disturb the list it was given", function()
+            -- The caller's specs are rebuilt from the timeline cache and reused
+            -- across filter taps. Reversing in place would flip them again on
+            -- the next rebuild, so the order would alternate on every redraw.
+            local given = specs()
+            plugin:timelineRowSpecs(given, true)
+            assert.are.equal("Ch 1", given[1].chapter)
+            assert.are.equal("Ch 3", given[3].chapter)
+        end)
+
+        it("holds up on an empty list", function()
+            assert.are.equal(0, #plugin:timelineRowSpecs({}, true))
+        end)
+
+    end)
+
     describe("timelinePriorSpecs", function()
 
         -- One consolidated recap per earlier book in the series, as

--- a/tools/spec_runner.lua
+++ b/tools/spec_runner.lua
@@ -157,7 +157,8 @@ local specs = {
     "spec/xray_units_spec.lua",
     "spec/xray_crypto_spec.lua",
     "spec/xray_websetup_spec.lua",
-    "spec/xray_imagemanager_spec.lua"
+    "spec/xray_imagemanager_spec.lua",
+    "spec/xray_presencemap_spec.lua"
 }
 
 if arg and arg[1] then

--- a/xray.koplugin/languages/ar.po
+++ b/xray.koplugin/languages/ar.po
@@ -899,11 +899,11 @@ msgstr "المخطط الزمني"
 
 # en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
 msgid "menu_timeline_all"
-msgstr "All"
+msgstr "الكل"
 
 # en-hash: 8b77f6081efcbe80501acb1411ddb510
 msgid "menu_timeline_presence_map"
-msgstr "Use Presence Map in Timeline"
+msgstr "استخدام خريطة الحضور في الخط الزمني"
 
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
@@ -1267,15 +1267,15 @@ msgstr "هذه الصفحة"
 
 # en-hash: 53468fd13ec60ce6e3944bab23cf96f7
 msgid "timeline_no_shared_chapters"
-msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
+msgstr "%s لا يظهران معًا في أي فصل.\n\nاضغط على %s لعرض الكتاب كاملاً."
 
 # en-hash: 88241ddd8e6f8ea848409c02dcd7549d
 msgid "timeline_sort_newest"
-msgstr "Newest first"
+msgstr "الأحدث أولاً"
 
 # en-hash: 799c95af138a2db03bfd6a597bb9fbe7
 msgid "timeline_sort_oldest"
-msgstr "Oldest first"
+msgstr "الأقدم أولاً"
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"

--- a/xray.koplugin/languages/ar.po
+++ b/xray.koplugin/languages/ar.po
@@ -897,6 +897,14 @@ msgstr "اختبار الاتصال"
 msgid "menu_timeline"
 msgstr "المخطط الزمني"
 
+# en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
+msgid "menu_timeline_all"
+msgstr "All"
+
+# en-hash: 8b77f6081efcbe80501acb1411ddb510
+msgid "menu_timeline_presence_map"
+msgstr "Use Presence Map in Timeline"
+
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
 msgstr "استخدام نمط الحاشية السفلية للبحث في النص"
@@ -1256,6 +1264,10 @@ msgstr "هذا الفصل"
 # en-hash: d2c24d59e0baff4d0155fbdf62590867
 msgid "this_page"
 msgstr "هذه الصفحة"
+
+# en-hash: 53468fd13ec60ce6e3944bab23cf96f7
+msgid "timeline_no_shared_chapters"
+msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
@@ -1696,4 +1708,3 @@ msgstr "يضيف زر 'X-Ray' إلى القواميس وقوائم التحدي�
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "نعم"
-

--- a/xray.koplugin/languages/ar.po
+++ b/xray.koplugin/languages/ar.po
@@ -1269,6 +1269,14 @@ msgstr "هذه الصفحة"
 msgid "timeline_no_shared_chapters"
 msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
+# en-hash: 88241ddd8e6f8ea848409c02dcd7549d
+msgid "timeline_sort_newest"
+msgstr "Newest first"
+
+# en-hash: 799c95af138a2db03bfd6a597bb9fbe7
+msgid "timeline_sort_oldest"
+msgstr "Oldest first"
+
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
 msgstr "Configure Settings..."
@@ -1708,3 +1716,4 @@ msgstr "يضيف زر 'X-Ray' إلى القواميس وقوائم التحدي�
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "نعم"
+

--- a/xray.koplugin/languages/de.po
+++ b/xray.koplugin/languages/de.po
@@ -1269,6 +1269,14 @@ msgstr "Diese Seite"
 msgid "timeline_no_shared_chapters"
 msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
+# en-hash: 88241ddd8e6f8ea848409c02dcd7549d
+msgid "timeline_sort_newest"
+msgstr "Newest first"
+
+# en-hash: 799c95af138a2db03bfd6a597bb9fbe7
+msgid "timeline_sort_oldest"
+msgstr "Oldest first"
+
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
 msgstr "Configure Settings..."
@@ -1708,3 +1716,4 @@ msgstr "Fügt eine 'X-Ray'-Schaltfläche zu Wörterbuch- und Auswahlmenüs für 
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "Ja"
+

--- a/xray.koplugin/languages/de.po
+++ b/xray.koplugin/languages/de.po
@@ -897,6 +897,14 @@ msgstr "Verbindung testen"
 msgid "menu_timeline"
 msgstr "Zeitstrahl"
 
+# en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
+msgid "menu_timeline_all"
+msgstr "All"
+
+# en-hash: 8b77f6081efcbe80501acb1411ddb510
+msgid "menu_timeline_presence_map"
+msgstr "Use Presence Map in Timeline"
+
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
 msgstr "Fußnoten-Stil für In-Text-Suche verwenden"
@@ -1256,6 +1264,10 @@ msgstr "Dieses Kapitel"
 # en-hash: d2c24d59e0baff4d0155fbdf62590867
 msgid "this_page"
 msgstr "Diese Seite"
+
+# en-hash: 53468fd13ec60ce6e3944bab23cf96f7
+msgid "timeline_no_shared_chapters"
+msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
@@ -1696,4 +1708,3 @@ msgstr "Fügt eine 'X-Ray'-Schaltfläche zu Wörterbuch- und Auswahlmenüs für 
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "Ja"
-

--- a/xray.koplugin/languages/de.po
+++ b/xray.koplugin/languages/de.po
@@ -899,11 +899,11 @@ msgstr "Zeitstrahl"
 
 # en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
 msgid "menu_timeline_all"
-msgstr "All"
+msgstr "Alle"
 
 # en-hash: 8b77f6081efcbe80501acb1411ddb510
 msgid "menu_timeline_presence_map"
-msgstr "Use Presence Map in Timeline"
+msgstr "Präsenzkarte in der Zeitleiste verwenden"
 
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
@@ -1267,15 +1267,15 @@ msgstr "Diese Seite"
 
 # en-hash: 53468fd13ec60ce6e3944bab23cf96f7
 msgid "timeline_no_shared_chapters"
-msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
+msgstr "%s teilen sich kein Kapitel.\n\nTippen Sie auf %s, um das ganze Buch zu sehen."
 
 # en-hash: 88241ddd8e6f8ea848409c02dcd7549d
 msgid "timeline_sort_newest"
-msgstr "Newest first"
+msgstr "Neueste zuerst"
 
 # en-hash: 799c95af138a2db03bfd6a597bb9fbe7
 msgid "timeline_sort_oldest"
-msgstr "Oldest first"
+msgstr "Älteste zuerst"
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"

--- a/xray.koplugin/languages/en.po
+++ b/xray.koplugin/languages/en.po
@@ -953,6 +953,12 @@ msgstr "Section"
 msgid "timeline_no_shared_chapters"
 msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
+msgid "timeline_sort_newest"
+msgstr "Newest first"
+
+msgid "timeline_sort_oldest"
+msgstr "Oldest first"
+
 msgid "unit_action_configure"
 msgstr "Configure Settings..."
 
@@ -1282,3 +1288,4 @@ msgstr "Adds an 'X-Ray' button to dictionary and selection menus for instant loo
 
 msgid "yes"
 msgstr "Yes"
+

--- a/xray.koplugin/languages/en.po
+++ b/xray.koplugin/languages/en.po
@@ -674,6 +674,12 @@ msgstr "Re-test"
 msgid "menu_timeline"
 msgstr "Timeline"
 
+msgid "menu_timeline_all"
+msgstr "All"
+
+msgid "menu_timeline_presence_map"
+msgstr "Use Presence Map in Timeline"
+
 msgid "menu_ui_popup_intext"
 msgstr "Use Footnote Style for In-text Lookups"
 
@@ -943,6 +949,9 @@ msgstr "This Chapter"
 
 msgid "this_page"
 msgstr "Section"
+
+msgid "timeline_no_shared_chapters"
+msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
 msgid "unit_action_configure"
 msgstr "Configure Settings..."
@@ -1273,4 +1282,3 @@ msgstr "Adds an 'X-Ray' button to dictionary and selection menus for instant loo
 
 msgid "yes"
 msgstr "Yes"
-

--- a/xray.koplugin/languages/es.po
+++ b/xray.koplugin/languages/es.po
@@ -897,6 +897,14 @@ msgstr "Probar conexión"
 msgid "menu_timeline"
 msgstr "Cronología"
 
+# en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
+msgid "menu_timeline_all"
+msgstr "All"
+
+# en-hash: 8b77f6081efcbe80501acb1411ddb510
+msgid "menu_timeline_presence_map"
+msgstr "Use Presence Map in Timeline"
+
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
 msgstr "Usar estilo de nota al pie para búsquedas en texto"
@@ -1256,6 +1264,10 @@ msgstr "Este Capítulo"
 # en-hash: d2c24d59e0baff4d0155fbdf62590867
 msgid "this_page"
 msgstr "Esta página"
+
+# en-hash: 53468fd13ec60ce6e3944bab23cf96f7
+msgid "timeline_no_shared_chapters"
+msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
@@ -1696,4 +1708,3 @@ msgstr "Añade un botón 'X-Ray' a los menús de diccionario y selección para c
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "Sí"
-

--- a/xray.koplugin/languages/es.po
+++ b/xray.koplugin/languages/es.po
@@ -899,11 +899,11 @@ msgstr "Cronología"
 
 # en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
 msgid "menu_timeline_all"
-msgstr "All"
+msgstr "Todos"
 
 # en-hash: 8b77f6081efcbe80501acb1411ddb510
 msgid "menu_timeline_presence_map"
-msgstr "Use Presence Map in Timeline"
+msgstr "Usar mapa de presencia en la cronología"
 
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
@@ -1267,15 +1267,15 @@ msgstr "Esta página"
 
 # en-hash: 53468fd13ec60ce6e3944bab23cf96f7
 msgid "timeline_no_shared_chapters"
-msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
+msgstr "%s no comparten ningún capítulo.\n\nToca %s para ver todo el libro."
 
 # en-hash: 88241ddd8e6f8ea848409c02dcd7549d
 msgid "timeline_sort_newest"
-msgstr "Newest first"
+msgstr "Más recientes primero"
 
 # en-hash: 799c95af138a2db03bfd6a597bb9fbe7
 msgid "timeline_sort_oldest"
-msgstr "Oldest first"
+msgstr "Más antiguos primero"
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"

--- a/xray.koplugin/languages/es.po
+++ b/xray.koplugin/languages/es.po
@@ -1269,6 +1269,14 @@ msgstr "Esta página"
 msgid "timeline_no_shared_chapters"
 msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
+# en-hash: 88241ddd8e6f8ea848409c02dcd7549d
+msgid "timeline_sort_newest"
+msgstr "Newest first"
+
+# en-hash: 799c95af138a2db03bfd6a597bb9fbe7
+msgid "timeline_sort_oldest"
+msgstr "Oldest first"
+
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
 msgstr "Configure Settings..."
@@ -1708,3 +1716,4 @@ msgstr "Añade un botón 'X-Ray' a los menús de diccionario y selección para c
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "Sí"
+

--- a/xray.koplugin/languages/fr.po
+++ b/xray.koplugin/languages/fr.po
@@ -899,11 +899,11 @@ msgstr "Chronologie"
 
 # en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
 msgid "menu_timeline_all"
-msgstr "All"
+msgstr "Tous"
 
 # en-hash: 8b77f6081efcbe80501acb1411ddb510
 msgid "menu_timeline_presence_map"
-msgstr "Use Presence Map in Timeline"
+msgstr "Utiliser la carte de présence dans la chronologie"
 
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
@@ -1267,15 +1267,15 @@ msgstr "Cette page"
 
 # en-hash: 53468fd13ec60ce6e3944bab23cf96f7
 msgid "timeline_no_shared_chapters"
-msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
+msgstr "%s ne partagent aucun chapitre.\n\nAppuyez sur %s pour voir tout le livre."
 
 # en-hash: 88241ddd8e6f8ea848409c02dcd7549d
 msgid "timeline_sort_newest"
-msgstr "Newest first"
+msgstr "Plus récents d'abord"
 
 # en-hash: 799c95af138a2db03bfd6a597bb9fbe7
 msgid "timeline_sort_oldest"
-msgstr "Oldest first"
+msgstr "Plus anciens d'abord"
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"

--- a/xray.koplugin/languages/fr.po
+++ b/xray.koplugin/languages/fr.po
@@ -1269,6 +1269,14 @@ msgstr "Cette page"
 msgid "timeline_no_shared_chapters"
 msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
+# en-hash: 88241ddd8e6f8ea848409c02dcd7549d
+msgid "timeline_sort_newest"
+msgstr "Newest first"
+
+# en-hash: 799c95af138a2db03bfd6a597bb9fbe7
+msgid "timeline_sort_oldest"
+msgstr "Oldest first"
+
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
 msgstr "Configure Settings..."
@@ -1708,3 +1716,4 @@ msgstr "Ajoute un bouton 'X-Ray' aux menus de dictionnaire et de sélection pour
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "Oui"
+

--- a/xray.koplugin/languages/fr.po
+++ b/xray.koplugin/languages/fr.po
@@ -897,6 +897,14 @@ msgstr "Tester la connexion"
 msgid "menu_timeline"
 msgstr "Chronologie"
 
+# en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
+msgid "menu_timeline_all"
+msgstr "All"
+
+# en-hash: 8b77f6081efcbe80501acb1411ddb510
+msgid "menu_timeline_presence_map"
+msgstr "Use Presence Map in Timeline"
+
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
 msgstr "Style note de bas de page pour recherche en texte"
@@ -1256,6 +1264,10 @@ msgstr "Ce chapitre"
 # en-hash: d2c24d59e0baff4d0155fbdf62590867
 msgid "this_page"
 msgstr "Cette page"
+
+# en-hash: 53468fd13ec60ce6e3944bab23cf96f7
+msgid "timeline_no_shared_chapters"
+msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
@@ -1696,4 +1708,3 @@ msgstr "Ajoute un bouton 'X-Ray' aux menus de dictionnaire et de sélection pour
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "Oui"
-

--- a/xray.koplugin/languages/hu.po
+++ b/xray.koplugin/languages/hu.po
@@ -897,6 +897,14 @@ msgstr "Kapcsolat tesztelése"
 msgid "menu_timeline"
 msgstr "Idővonal"
 
+# en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
+msgid "menu_timeline_all"
+msgstr "All"
+
+# en-hash: 8b77f6081efcbe80501acb1411ddb510
+msgid "menu_timeline_presence_map"
+msgstr "Use Presence Map in Timeline"
+
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
 msgstr "Lábjegyzet stílus használata szövegben történő kereséshez"
@@ -1256,6 +1264,10 @@ msgstr "Ez a fejezet"
 # en-hash: d2c24d59e0baff4d0155fbdf62590867
 msgid "this_page"
 msgstr "Ez az oldal"
+
+# en-hash: 53468fd13ec60ce6e3944bab23cf96f7
+msgid "timeline_no_shared_chapters"
+msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
@@ -1696,4 +1708,3 @@ msgstr "Hozzáad egy 'X-Ray' gombot a szótár és kijelölés menükhöz az azo
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "Igen"
-

--- a/xray.koplugin/languages/hu.po
+++ b/xray.koplugin/languages/hu.po
@@ -899,11 +899,11 @@ msgstr "Idővonal"
 
 # en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
 msgid "menu_timeline_all"
-msgstr "All"
+msgstr "Mind"
 
 # en-hash: 8b77f6081efcbe80501acb1411ddb510
 msgid "menu_timeline_presence_map"
-msgstr "Use Presence Map in Timeline"
+msgstr "Jelenléti térkép használata az idővonalon"
 
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
@@ -1267,15 +1267,15 @@ msgstr "Ez az oldal"
 
 # en-hash: 53468fd13ec60ce6e3944bab23cf96f7
 msgid "timeline_no_shared_chapters"
-msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
+msgstr "%s nem szerepelnek közös fejezetben.\n\nKoppintson a(z) %s elemre a teljes könyvhöz."
 
 # en-hash: 88241ddd8e6f8ea848409c02dcd7549d
 msgid "timeline_sort_newest"
-msgstr "Newest first"
+msgstr "Legújabb elöl"
 
 # en-hash: 799c95af138a2db03bfd6a597bb9fbe7
 msgid "timeline_sort_oldest"
-msgstr "Oldest first"
+msgstr "Legrégebbi elöl"
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"

--- a/xray.koplugin/languages/hu.po
+++ b/xray.koplugin/languages/hu.po
@@ -1269,6 +1269,14 @@ msgstr "Ez az oldal"
 msgid "timeline_no_shared_chapters"
 msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
+# en-hash: 88241ddd8e6f8ea848409c02dcd7549d
+msgid "timeline_sort_newest"
+msgstr "Newest first"
+
+# en-hash: 799c95af138a2db03bfd6a597bb9fbe7
+msgid "timeline_sort_oldest"
+msgstr "Oldest first"
+
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
 msgstr "Configure Settings..."
@@ -1708,3 +1716,4 @@ msgstr "Hozzáad egy 'X-Ray' gombot a szótár és kijelölés menükhöz az azo
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "Igen"
+

--- a/xray.koplugin/languages/id.po
+++ b/xray.koplugin/languages/id.po
@@ -1269,6 +1269,14 @@ msgstr "Halaman Ini"
 msgid "timeline_no_shared_chapters"
 msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
+# en-hash: 88241ddd8e6f8ea848409c02dcd7549d
+msgid "timeline_sort_newest"
+msgstr "Newest first"
+
+# en-hash: 799c95af138a2db03bfd6a597bb9fbe7
+msgid "timeline_sort_oldest"
+msgstr "Oldest first"
+
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
 msgstr "Configure Settings..."
@@ -1708,3 +1716,4 @@ msgstr "Menambahkan tombol 'X-Ray' ke menu kamus dan pilihan untuk pencarian ins
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "Ya"
+

--- a/xray.koplugin/languages/id.po
+++ b/xray.koplugin/languages/id.po
@@ -897,6 +897,14 @@ msgstr "Uji Sambungan"
 msgid "menu_timeline"
 msgstr "Lini Masa"
 
+# en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
+msgid "menu_timeline_all"
+msgstr "All"
+
+# en-hash: 8b77f6081efcbe80501acb1411ddb510
+msgid "menu_timeline_presence_map"
+msgstr "Use Presence Map in Timeline"
+
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
 msgstr "Gunakan Gaya Catatan Kaki untuk Pencarian Dalam Teks"
@@ -1256,6 +1264,10 @@ msgstr "Bab Ini"
 # en-hash: d2c24d59e0baff4d0155fbdf62590867
 msgid "this_page"
 msgstr "Halaman Ini"
+
+# en-hash: 53468fd13ec60ce6e3944bab23cf96f7
+msgid "timeline_no_shared_chapters"
+msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
@@ -1696,4 +1708,3 @@ msgstr "Menambahkan tombol 'X-Ray' ke menu kamus dan pilihan untuk pencarian ins
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "Ya"
-

--- a/xray.koplugin/languages/id.po
+++ b/xray.koplugin/languages/id.po
@@ -899,11 +899,11 @@ msgstr "Lini Masa"
 
 # en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
 msgid "menu_timeline_all"
-msgstr "All"
+msgstr "Semua"
 
 # en-hash: 8b77f6081efcbe80501acb1411ddb510
 msgid "menu_timeline_presence_map"
-msgstr "Use Presence Map in Timeline"
+msgstr "Gunakan peta kehadiran di lini masa"
 
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
@@ -1267,15 +1267,15 @@ msgstr "Halaman Ini"
 
 # en-hash: 53468fd13ec60ce6e3944bab23cf96f7
 msgid "timeline_no_shared_chapters"
-msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
+msgstr "%s tidak pernah berada di bab yang sama.\n\nKetuk %s untuk melihat seluruh buku."
 
 # en-hash: 88241ddd8e6f8ea848409c02dcd7549d
 msgid "timeline_sort_newest"
-msgstr "Newest first"
+msgstr "Terbaru dulu"
 
 # en-hash: 799c95af138a2db03bfd6a597bb9fbe7
 msgid "timeline_sort_oldest"
-msgstr "Oldest first"
+msgstr "Terlama dulu"
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"

--- a/xray.koplugin/languages/it.po
+++ b/xray.koplugin/languages/it.po
@@ -899,11 +899,11 @@ msgstr "Cronologia"
 
 # en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
 msgid "menu_timeline_all"
-msgstr "All"
+msgstr "Tutti"
 
 # en-hash: 8b77f6081efcbe80501acb1411ddb510
 msgid "menu_timeline_presence_map"
-msgstr "Use Presence Map in Timeline"
+msgstr "Usa la mappa delle presenze nella cronologia"
 
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
@@ -1267,15 +1267,15 @@ msgstr "Questa pagina"
 
 # en-hash: 53468fd13ec60ce6e3944bab23cf96f7
 msgid "timeline_no_shared_chapters"
-msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
+msgstr "%s non compaiono nello stesso capitolo.\n\nTocca %s per vedere l'intero libro."
 
 # en-hash: 88241ddd8e6f8ea848409c02dcd7549d
 msgid "timeline_sort_newest"
-msgstr "Newest first"
+msgstr "Più recenti prima"
 
 # en-hash: 799c95af138a2db03bfd6a597bb9fbe7
 msgid "timeline_sort_oldest"
-msgstr "Oldest first"
+msgstr "Meno recenti prima"
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"

--- a/xray.koplugin/languages/it.po
+++ b/xray.koplugin/languages/it.po
@@ -1269,6 +1269,14 @@ msgstr "Questa pagina"
 msgid "timeline_no_shared_chapters"
 msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
+# en-hash: 88241ddd8e6f8ea848409c02dcd7549d
+msgid "timeline_sort_newest"
+msgstr "Newest first"
+
+# en-hash: 799c95af138a2db03bfd6a597bb9fbe7
+msgid "timeline_sort_oldest"
+msgstr "Oldest first"
+
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
 msgstr "Configure Settings..."
@@ -1708,3 +1716,4 @@ msgstr "Aggiunge un pulsante \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "SÌ"
+

--- a/xray.koplugin/languages/it.po
+++ b/xray.koplugin/languages/it.po
@@ -897,6 +897,14 @@ msgstr "Testa connessione"
 msgid "menu_timeline"
 msgstr "Cronologia"
 
+# en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
+msgid "menu_timeline_all"
+msgstr "All"
+
+# en-hash: 8b77f6081efcbe80501acb1411ddb510
+msgid "menu_timeline_presence_map"
+msgstr "Use Presence Map in Timeline"
+
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
 msgstr "Utilizza lo stile della nota a piè di pagina per le ricerche nel testo"
@@ -1256,6 +1264,10 @@ msgstr "Questo capitolo"
 # en-hash: d2c24d59e0baff4d0155fbdf62590867
 msgid "this_page"
 msgstr "Questa pagina"
+
+# en-hash: 53468fd13ec60ce6e3944bab23cf96f7
+msgid "timeline_no_shared_chapters"
+msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
@@ -1696,4 +1708,3 @@ msgstr "Aggiunge un pulsante \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "SÌ"
-

--- a/xray.koplugin/languages/ja.po
+++ b/xray.koplugin/languages/ja.po
@@ -897,6 +897,14 @@ msgstr "接続テスト"
 msgid "menu_timeline"
 msgstr "出来事"
 
+# en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
+msgid "menu_timeline_all"
+msgstr "All"
+
+# en-hash: 8b77f6081efcbe80501acb1411ddb510
+msgid "menu_timeline_presence_map"
+msgstr "Use Presence Map in Timeline"
+
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
 msgstr "本文検索に脚注スタイルを使用"
@@ -1256,6 +1264,10 @@ msgstr "この章"
 # en-hash: d2c24d59e0baff4d0155fbdf62590867
 msgid "this_page"
 msgstr "セクション"
+
+# en-hash: 53468fd13ec60ce6e3944bab23cf96f7
+msgid "timeline_no_shared_chapters"
+msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
@@ -1696,4 +1708,3 @@ msgstr "辞書および選択メニューに「X-Ray」ボタンを追加し、�
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "はい"
-

--- a/xray.koplugin/languages/ja.po
+++ b/xray.koplugin/languages/ja.po
@@ -899,11 +899,11 @@ msgstr "出来事"
 
 # en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
 msgid "menu_timeline_all"
-msgstr "All"
+msgstr "すべて"
 
 # en-hash: 8b77f6081efcbe80501acb1411ddb510
 msgid "menu_timeline_presence_map"
-msgstr "Use Presence Map in Timeline"
+msgstr "タイムラインで登場マップを使用"
 
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
@@ -1267,15 +1267,15 @@ msgstr "セクション"
 
 # en-hash: 53468fd13ec60ce6e3944bab23cf96f7
 msgid "timeline_no_shared_chapters"
-msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
+msgstr "%s は同じ章に登場しません。\n\n%s をタップすると本全体が表示されます。"
 
 # en-hash: 88241ddd8e6f8ea848409c02dcd7549d
 msgid "timeline_sort_newest"
-msgstr "Newest first"
+msgstr "新しい順"
 
 # en-hash: 799c95af138a2db03bfd6a597bb9fbe7
 msgid "timeline_sort_oldest"
-msgstr "Oldest first"
+msgstr "古い順"
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"

--- a/xray.koplugin/languages/ja.po
+++ b/xray.koplugin/languages/ja.po
@@ -1269,6 +1269,14 @@ msgstr "セクション"
 msgid "timeline_no_shared_chapters"
 msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
+# en-hash: 88241ddd8e6f8ea848409c02dcd7549d
+msgid "timeline_sort_newest"
+msgstr "Newest first"
+
+# en-hash: 799c95af138a2db03bfd6a597bb9fbe7
+msgid "timeline_sort_oldest"
+msgstr "Oldest first"
+
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
 msgstr "設定を変更..."
@@ -1708,3 +1716,4 @@ msgstr "辞書および選択メニューに「X-Ray」ボタンを追加し、�
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "はい"
+

--- a/xray.koplugin/languages/nl.po
+++ b/xray.koplugin/languages/nl.po
@@ -897,6 +897,14 @@ msgstr "Verbinding testen"
 msgid "menu_timeline"
 msgstr "Tijdlijn"
 
+# en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
+msgid "menu_timeline_all"
+msgstr "All"
+
+# en-hash: 8b77f6081efcbe80501acb1411ddb510
+msgid "menu_timeline_presence_map"
+msgstr "Use Presence Map in Timeline"
+
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
 msgstr "Voetnootstijl gebruiken voor in-text-opzoeken"
@@ -1256,6 +1264,10 @@ msgstr "Dit hoofdstuk"
 # en-hash: d2c24d59e0baff4d0155fbdf62590867
 msgid "this_page"
 msgstr "Deze pagina"
+
+# en-hash: 53468fd13ec60ce6e3944bab23cf96f7
+msgid "timeline_no_shared_chapters"
+msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
@@ -1696,4 +1708,3 @@ msgstr "Voegt een 'X-Ray'-knop toe aan woordenboek- en selectiemenu's voor direc
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "Ja"
-

--- a/xray.koplugin/languages/nl.po
+++ b/xray.koplugin/languages/nl.po
@@ -1269,6 +1269,14 @@ msgstr "Deze pagina"
 msgid "timeline_no_shared_chapters"
 msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
+# en-hash: 88241ddd8e6f8ea848409c02dcd7549d
+msgid "timeline_sort_newest"
+msgstr "Newest first"
+
+# en-hash: 799c95af138a2db03bfd6a597bb9fbe7
+msgid "timeline_sort_oldest"
+msgstr "Oldest first"
+
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
 msgstr "Configure Settings..."
@@ -1708,3 +1716,4 @@ msgstr "Voegt een 'X-Ray'-knop toe aan woordenboek- en selectiemenu's voor direc
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "Ja"
+

--- a/xray.koplugin/languages/nl.po
+++ b/xray.koplugin/languages/nl.po
@@ -899,11 +899,11 @@ msgstr "Tijdlijn"
 
 # en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
 msgid "menu_timeline_all"
-msgstr "All"
+msgstr "Alle"
 
 # en-hash: 8b77f6081efcbe80501acb1411ddb510
 msgid "menu_timeline_presence_map"
-msgstr "Use Presence Map in Timeline"
+msgstr "Aanwezigheidskaart in tijdlijn gebruiken"
 
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
@@ -1267,15 +1267,15 @@ msgstr "Deze pagina"
 
 # en-hash: 53468fd13ec60ce6e3944bab23cf96f7
 msgid "timeline_no_shared_chapters"
-msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
+msgstr "%s delen geen hoofdstuk.\n\nTik op %s om het hele boek te zien."
 
 # en-hash: 88241ddd8e6f8ea848409c02dcd7549d
 msgid "timeline_sort_newest"
-msgstr "Newest first"
+msgstr "Nieuwste eerst"
 
 # en-hash: 799c95af138a2db03bfd6a597bb9fbe7
 msgid "timeline_sort_oldest"
-msgstr "Oldest first"
+msgstr "Oudste eerst"
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"

--- a/xray.koplugin/languages/pl.po
+++ b/xray.koplugin/languages/pl.po
@@ -1269,6 +1269,14 @@ msgstr "Ta strona"
 msgid "timeline_no_shared_chapters"
 msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
+# en-hash: 88241ddd8e6f8ea848409c02dcd7549d
+msgid "timeline_sort_newest"
+msgstr "Newest first"
+
+# en-hash: 799c95af138a2db03bfd6a597bb9fbe7
+msgid "timeline_sort_oldest"
+msgstr "Oldest first"
+
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
 msgstr "Configure Settings..."
@@ -1708,3 +1716,4 @@ msgstr "Dodaje przycisk 'X-Ray' do menu słownika i wyboru w celu natychmiastowe
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "Tak"
+

--- a/xray.koplugin/languages/pl.po
+++ b/xray.koplugin/languages/pl.po
@@ -897,6 +897,14 @@ msgstr "Testuj połączenie"
 msgid "menu_timeline"
 msgstr "Oś czasu"
 
+# en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
+msgid "menu_timeline_all"
+msgstr "All"
+
+# en-hash: 8b77f6081efcbe80501acb1411ddb510
+msgid "menu_timeline_presence_map"
+msgstr "Use Presence Map in Timeline"
+
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
 msgstr "Styl przypisu dla wyszukiwania w tekście"
@@ -1256,6 +1264,10 @@ msgstr "Ten rozdział"
 # en-hash: d2c24d59e0baff4d0155fbdf62590867
 msgid "this_page"
 msgstr "Ta strona"
+
+# en-hash: 53468fd13ec60ce6e3944bab23cf96f7
+msgid "timeline_no_shared_chapters"
+msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
@@ -1696,4 +1708,3 @@ msgstr "Dodaje przycisk 'X-Ray' do menu słownika i wyboru w celu natychmiastowe
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "Tak"
-

--- a/xray.koplugin/languages/pl.po
+++ b/xray.koplugin/languages/pl.po
@@ -899,11 +899,11 @@ msgstr "Oś czasu"
 
 # en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
 msgid "menu_timeline_all"
-msgstr "All"
+msgstr "Wszystkie"
 
 # en-hash: 8b77f6081efcbe80501acb1411ddb510
 msgid "menu_timeline_presence_map"
-msgstr "Use Presence Map in Timeline"
+msgstr "Użyj mapy obecności na osi czasu"
 
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
@@ -1267,15 +1267,15 @@ msgstr "Ta strona"
 
 # en-hash: 53468fd13ec60ce6e3944bab23cf96f7
 msgid "timeline_no_shared_chapters"
-msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
+msgstr "%s nie występują w tym samym rozdziale.\n\nDotknij %s, aby zobaczyć całą książkę."
 
 # en-hash: 88241ddd8e6f8ea848409c02dcd7549d
 msgid "timeline_sort_newest"
-msgstr "Newest first"
+msgstr "Najnowsze najpierw"
 
 # en-hash: 799c95af138a2db03bfd6a597bb9fbe7
 msgid "timeline_sort_oldest"
-msgstr "Oldest first"
+msgstr "Najstarsze najpierw"
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"

--- a/xray.koplugin/languages/pt_br.po
+++ b/xray.koplugin/languages/pt_br.po
@@ -897,6 +897,14 @@ msgstr "Testar conexão"
 msgid "menu_timeline"
 msgstr "Linha do Tempo"
 
+# en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
+msgid "menu_timeline_all"
+msgstr "All"
+
+# en-hash: 8b77f6081efcbe80501acb1411ddb510
+msgid "menu_timeline_presence_map"
+msgstr "Use Presence Map in Timeline"
+
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
 msgstr "Usar estilo nota de rodapé para buscas no texto"
@@ -1256,6 +1264,10 @@ msgstr "Este Capítulo"
 # en-hash: d2c24d59e0baff4d0155fbdf62590867
 msgid "this_page"
 msgstr "Esta Página"
+
+# en-hash: 53468fd13ec60ce6e3944bab23cf96f7
+msgid "timeline_no_shared_chapters"
+msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
@@ -1696,4 +1708,3 @@ msgstr "Adiciona um botão 'X-Ray' aos menus de dicionário e seleção para con
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "Sim"
-

--- a/xray.koplugin/languages/pt_br.po
+++ b/xray.koplugin/languages/pt_br.po
@@ -899,11 +899,11 @@ msgstr "Linha do Tempo"
 
 # en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
 msgid "menu_timeline_all"
-msgstr "All"
+msgstr "Todos"
 
 # en-hash: 8b77f6081efcbe80501acb1411ddb510
 msgid "menu_timeline_presence_map"
-msgstr "Use Presence Map in Timeline"
+msgstr "Usar mapa de presença na linha do tempo"
 
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
@@ -1267,15 +1267,15 @@ msgstr "Esta Página"
 
 # en-hash: 53468fd13ec60ce6e3944bab23cf96f7
 msgid "timeline_no_shared_chapters"
-msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
+msgstr "%s não compartilham nenhum capítulo.\n\nToque em %s para ver o livro inteiro."
 
 # en-hash: 88241ddd8e6f8ea848409c02dcd7549d
 msgid "timeline_sort_newest"
-msgstr "Newest first"
+msgstr "Mais recentes primeiro"
 
 # en-hash: 799c95af138a2db03bfd6a597bb9fbe7
 msgid "timeline_sort_oldest"
-msgstr "Oldest first"
+msgstr "Mais antigos primeiro"
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"

--- a/xray.koplugin/languages/pt_br.po
+++ b/xray.koplugin/languages/pt_br.po
@@ -1269,6 +1269,14 @@ msgstr "Esta Página"
 msgid "timeline_no_shared_chapters"
 msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
+# en-hash: 88241ddd8e6f8ea848409c02dcd7549d
+msgid "timeline_sort_newest"
+msgstr "Newest first"
+
+# en-hash: 799c95af138a2db03bfd6a597bb9fbe7
+msgid "timeline_sort_oldest"
+msgstr "Oldest first"
+
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
 msgstr "Configure Settings..."
@@ -1708,3 +1716,4 @@ msgstr "Adiciona um botão 'X-Ray' aos menus de dicionário e seleção para con
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "Sim"
+

--- a/xray.koplugin/languages/ru.po
+++ b/xray.koplugin/languages/ru.po
@@ -1269,6 +1269,14 @@ msgstr "Эта страница"
 msgid "timeline_no_shared_chapters"
 msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
+# en-hash: 88241ddd8e6f8ea848409c02dcd7549d
+msgid "timeline_sort_newest"
+msgstr "Newest first"
+
+# en-hash: 799c95af138a2db03bfd6a597bb9fbe7
+msgid "timeline_sort_oldest"
+msgstr "Oldest first"
+
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
 msgstr "Configure Settings..."
@@ -1708,3 +1716,4 @@ msgstr "Добавляет кнопку 'X-Ray' в меню словаря и в
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "Да"
+

--- a/xray.koplugin/languages/ru.po
+++ b/xray.koplugin/languages/ru.po
@@ -899,11 +899,11 @@ msgstr "Хронология"
 
 # en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
 msgid "menu_timeline_all"
-msgstr "All"
+msgstr "Все"
 
 # en-hash: 8b77f6081efcbe80501acb1411ddb510
 msgid "menu_timeline_presence_map"
-msgstr "Use Presence Map in Timeline"
+msgstr "Использовать карту присутствия на шкале времени"
 
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
@@ -1267,15 +1267,15 @@ msgstr "Эта страница"
 
 # en-hash: 53468fd13ec60ce6e3944bab23cf96f7
 msgid "timeline_no_shared_chapters"
-msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
+msgstr "%s не встречаются в одной главе.\n\nНажмите «%s», чтобы увидеть всю книгу."
 
 # en-hash: 88241ddd8e6f8ea848409c02dcd7549d
 msgid "timeline_sort_newest"
-msgstr "Newest first"
+msgstr "Сначала новые"
 
 # en-hash: 799c95af138a2db03bfd6a597bb9fbe7
 msgid "timeline_sort_oldest"
-msgstr "Oldest first"
+msgstr "Сначала старые"
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"

--- a/xray.koplugin/languages/ru.po
+++ b/xray.koplugin/languages/ru.po
@@ -897,6 +897,14 @@ msgstr "Проверить соединение"
 msgid "menu_timeline"
 msgstr "Хронология"
 
+# en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
+msgid "menu_timeline_all"
+msgstr "All"
+
+# en-hash: 8b77f6081efcbe80501acb1411ddb510
+msgid "menu_timeline_presence_map"
+msgstr "Use Presence Map in Timeline"
+
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
 msgstr "Сноски вместо всплывающих окон в тексте"
@@ -1256,6 +1264,10 @@ msgstr "Эта глава"
 # en-hash: d2c24d59e0baff4d0155fbdf62590867
 msgid "this_page"
 msgstr "Эта страница"
+
+# en-hash: 53468fd13ec60ce6e3944bab23cf96f7
+msgid "timeline_no_shared_chapters"
+msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
@@ -1696,4 +1708,3 @@ msgstr "Добавляет кнопку 'X-Ray' в меню словаря и в
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "Да"
-

--- a/xray.koplugin/languages/sr.po
+++ b/xray.koplugin/languages/sr.po
@@ -1269,6 +1269,14 @@ msgstr "Ова страница"
 msgid "timeline_no_shared_chapters"
 msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
+# en-hash: 88241ddd8e6f8ea848409c02dcd7549d
+msgid "timeline_sort_newest"
+msgstr "Newest first"
+
+# en-hash: 799c95af138a2db03bfd6a597bb9fbe7
+msgid "timeline_sort_oldest"
+msgstr "Oldest first"
+
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
 msgstr "Configure Settings..."
@@ -1708,3 +1716,4 @@ msgstr "Додаје дугме 'X-Ray' у речнике и селекцион�
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "Да"
+

--- a/xray.koplugin/languages/sr.po
+++ b/xray.koplugin/languages/sr.po
@@ -899,11 +899,11 @@ msgstr "Хронологија"
 
 # en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
 msgid "menu_timeline_all"
-msgstr "All"
+msgstr "Сви"
 
 # en-hash: 8b77f6081efcbe80501acb1411ddb510
 msgid "menu_timeline_presence_map"
-msgstr "Use Presence Map in Timeline"
+msgstr "Користи мапу присуства на временској оси"
 
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
@@ -1267,15 +1267,15 @@ msgstr "Ова страница"
 
 # en-hash: 53468fd13ec60ce6e3944bab23cf96f7
 msgid "timeline_no_shared_chapters"
-msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
+msgstr "%s се не појављују у истом поглављу.\n\nДодирните %s да видите целу књигу."
 
 # en-hash: 88241ddd8e6f8ea848409c02dcd7549d
 msgid "timeline_sort_newest"
-msgstr "Newest first"
+msgstr "Прво најновије"
 
 # en-hash: 799c95af138a2db03bfd6a597bb9fbe7
 msgid "timeline_sort_oldest"
-msgstr "Oldest first"
+msgstr "Прво најстарије"
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"

--- a/xray.koplugin/languages/sr.po
+++ b/xray.koplugin/languages/sr.po
@@ -897,6 +897,14 @@ msgstr "Тестирај везу"
 msgid "menu_timeline"
 msgstr "Хронологија"
 
+# en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
+msgid "menu_timeline_all"
+msgstr "All"
+
+# en-hash: 8b77f6081efcbe80501acb1411ddb510
+msgid "menu_timeline_presence_map"
+msgstr "Use Presence Map in Timeline"
+
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
 msgstr "Користи фуснота-стил за претрагу у тексту"
@@ -1256,6 +1264,10 @@ msgstr "Ово поглавље"
 # en-hash: d2c24d59e0baff4d0155fbdf62590867
 msgid "this_page"
 msgstr "Ова страница"
+
+# en-hash: 53468fd13ec60ce6e3944bab23cf96f7
+msgid "timeline_no_shared_chapters"
+msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
@@ -1696,4 +1708,3 @@ msgstr "Додаје дугме 'X-Ray' у речнике и селекцион�
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "Да"
-

--- a/xray.koplugin/languages/tr.po
+++ b/xray.koplugin/languages/tr.po
@@ -897,6 +897,14 @@ msgstr "Bağlantıyı Test Et"
 msgid "menu_timeline"
 msgstr "Zaman Çizelgesi"
 
+# en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
+msgid "menu_timeline_all"
+msgstr "All"
+
+# en-hash: 8b77f6081efcbe80501acb1411ddb510
+msgid "menu_timeline_presence_map"
+msgstr "Use Presence Map in Timeline"
+
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
 msgstr "Metin içi aramalar için Dipnot Stilini kullan"
@@ -1256,6 +1264,10 @@ msgstr "Bu Bölüm"
 # en-hash: d2c24d59e0baff4d0155fbdf62590867
 msgid "this_page"
 msgstr "Bu Sayfa"
+
+# en-hash: 53468fd13ec60ce6e3944bab23cf96f7
+msgid "timeline_no_shared_chapters"
+msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
@@ -1696,4 +1708,3 @@ msgstr "Anında arama yapmak için sözlük ve seçim menülerine bir 'X-Ray' d�
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "Evet"
-

--- a/xray.koplugin/languages/tr.po
+++ b/xray.koplugin/languages/tr.po
@@ -1269,6 +1269,14 @@ msgstr "Bu Sayfa"
 msgid "timeline_no_shared_chapters"
 msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
+# en-hash: 88241ddd8e6f8ea848409c02dcd7549d
+msgid "timeline_sort_newest"
+msgstr "Newest first"
+
+# en-hash: 799c95af138a2db03bfd6a597bb9fbe7
+msgid "timeline_sort_oldest"
+msgstr "Oldest first"
+
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
 msgstr "Configure Settings..."
@@ -1708,3 +1716,4 @@ msgstr "Anında arama yapmak için sözlük ve seçim menülerine bir 'X-Ray' d�
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "Evet"
+

--- a/xray.koplugin/languages/tr.po
+++ b/xray.koplugin/languages/tr.po
@@ -899,11 +899,11 @@ msgstr "Zaman Çizelgesi"
 
 # en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
 msgid "menu_timeline_all"
-msgstr "All"
+msgstr "Tümü"
 
 # en-hash: 8b77f6081efcbe80501acb1411ddb510
 msgid "menu_timeline_presence_map"
-msgstr "Use Presence Map in Timeline"
+msgstr "Zaman çizelgesinde varlık haritasını kullan"
 
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
@@ -1267,15 +1267,15 @@ msgstr "Bu Sayfa"
 
 # en-hash: 53468fd13ec60ce6e3944bab23cf96f7
 msgid "timeline_no_shared_chapters"
-msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
+msgstr "%s hiçbir bölümü paylaşmıyor.\n\nTüm kitabı görmek için %s ögesine dokunun."
 
 # en-hash: 88241ddd8e6f8ea848409c02dcd7549d
 msgid "timeline_sort_newest"
-msgstr "Newest first"
+msgstr "Önce en yeni"
 
 # en-hash: 799c95af138a2db03bfd6a597bb9fbe7
 msgid "timeline_sort_oldest"
-msgstr "Oldest first"
+msgstr "Önce en eski"
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"

--- a/xray.koplugin/languages/uk.po
+++ b/xray.koplugin/languages/uk.po
@@ -1269,6 +1269,14 @@ msgstr "Ця сторінка"
 msgid "timeline_no_shared_chapters"
 msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
+# en-hash: 88241ddd8e6f8ea848409c02dcd7549d
+msgid "timeline_sort_newest"
+msgstr "Newest first"
+
+# en-hash: 799c95af138a2db03bfd6a597bb9fbe7
+msgid "timeline_sort_oldest"
+msgstr "Oldest first"
+
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
 msgstr "Configure Settings..."
@@ -1708,3 +1716,4 @@ msgstr "Додає кнопку 'X-Ray' у меню словника та вид
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "Так"
+

--- a/xray.koplugin/languages/uk.po
+++ b/xray.koplugin/languages/uk.po
@@ -897,6 +897,14 @@ msgstr "Перевірити з'єднання"
 msgid "menu_timeline"
 msgstr "Хронологія"
 
+# en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
+msgid "menu_timeline_all"
+msgstr "All"
+
+# en-hash: 8b77f6081efcbe80501acb1411ddb510
+msgid "menu_timeline_presence_map"
+msgstr "Use Presence Map in Timeline"
+
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
 msgstr "Сноски замість спливаючих вікон у тексті"
@@ -1256,6 +1264,10 @@ msgstr "Цей розділ"
 # en-hash: d2c24d59e0baff4d0155fbdf62590867
 msgid "this_page"
 msgstr "Ця сторінка"
+
+# en-hash: 53468fd13ec60ce6e3944bab23cf96f7
+msgid "timeline_no_shared_chapters"
+msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
@@ -1696,4 +1708,3 @@ msgstr "Додає кнопку 'X-Ray' у меню словника та вид
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "Так"
-

--- a/xray.koplugin/languages/uk.po
+++ b/xray.koplugin/languages/uk.po
@@ -899,11 +899,11 @@ msgstr "Хронологія"
 
 # en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
 msgid "menu_timeline_all"
-msgstr "All"
+msgstr "Усі"
 
 # en-hash: 8b77f6081efcbe80501acb1411ddb510
 msgid "menu_timeline_presence_map"
-msgstr "Use Presence Map in Timeline"
+msgstr "Використовувати карту присутності на шкалі часу"
 
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
@@ -1267,15 +1267,15 @@ msgstr "Ця сторінка"
 
 # en-hash: 53468fd13ec60ce6e3944bab23cf96f7
 msgid "timeline_no_shared_chapters"
-msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
+msgstr "%s не зустрічаються в одному розділі.\n\nНатисніть «%s», щоб побачити всю книгу."
 
 # en-hash: 88241ddd8e6f8ea848409c02dcd7549d
 msgid "timeline_sort_newest"
-msgstr "Newest first"
+msgstr "Спочатку нові"
 
 # en-hash: 799c95af138a2db03bfd6a597bb9fbe7
 msgid "timeline_sort_oldest"
-msgstr "Oldest first"
+msgstr "Спочатку старі"
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"

--- a/xray.koplugin/languages/zh_CN.po
+++ b/xray.koplugin/languages/zh_CN.po
@@ -1269,6 +1269,14 @@ msgstr "当前页"
 msgid "timeline_no_shared_chapters"
 msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
+# en-hash: 88241ddd8e6f8ea848409c02dcd7549d
+msgid "timeline_sort_newest"
+msgstr "Newest first"
+
+# en-hash: 799c95af138a2db03bfd6a597bb9fbe7
+msgid "timeline_sort_oldest"
+msgstr "Oldest first"
+
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
 msgstr "Configure Settings..."
@@ -1708,3 +1716,4 @@ msgstr "在字典和选择菜单中添加“X-Ray”按钮，实现即时查询�
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "是"
+

--- a/xray.koplugin/languages/zh_CN.po
+++ b/xray.koplugin/languages/zh_CN.po
@@ -899,11 +899,11 @@ msgstr "时间线"
 
 # en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
 msgid "menu_timeline_all"
-msgstr "All"
+msgstr "全部"
 
 # en-hash: 8b77f6081efcbe80501acb1411ddb510
 msgid "menu_timeline_presence_map"
-msgstr "Use Presence Map in Timeline"
+msgstr "在时间线中使用出场图"
 
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
@@ -1267,15 +1267,15 @@ msgstr "当前页"
 
 # en-hash: 53468fd13ec60ce6e3944bab23cf96f7
 msgid "timeline_no_shared_chapters"
-msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
+msgstr "%s 没有出现在同一章节。\n\n点击「%s」查看整本书。"
 
 # en-hash: 88241ddd8e6f8ea848409c02dcd7549d
 msgid "timeline_sort_newest"
-msgstr "Newest first"
+msgstr "从新到旧"
 
 # en-hash: 799c95af138a2db03bfd6a597bb9fbe7
 msgid "timeline_sort_oldest"
-msgstr "Oldest first"
+msgstr "从旧到新"
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"

--- a/xray.koplugin/languages/zh_CN.po
+++ b/xray.koplugin/languages/zh_CN.po
@@ -897,6 +897,14 @@ msgstr "测试连接"
 msgid "menu_timeline"
 msgstr "时间线"
 
+# en-hash: b1c94ca2fbc3e78fc30069c8d0f01680
+msgid "menu_timeline_all"
+msgstr "All"
+
+# en-hash: 8b77f6081efcbe80501acb1411ddb510
+msgid "menu_timeline_presence_map"
+msgstr "Use Presence Map in Timeline"
+
 # en-hash: 3c1fa918adf3e65fbff595ee1fd50d26
 msgid "menu_ui_popup_intext"
 msgstr "书中查询使用脚注样式"
@@ -1256,6 +1264,10 @@ msgstr "本章"
 # en-hash: d2c24d59e0baff4d0155fbdf62590867
 msgid "this_page"
 msgstr "当前页"
+
+# en-hash: 53468fd13ec60ce6e3944bab23cf96f7
+msgid "timeline_no_shared_chapters"
+msgstr "%s never share a chapter.\n\nTap %s to see the whole book."
 
 # en-hash: f61824b403008733ff955da48052ee04
 msgid "unit_action_configure"
@@ -1696,4 +1708,3 @@ msgstr "在字典和选择菜单中添加“X-Ray”按钮，实现即时查询�
 # en-hash: 93cba07454f06a4a960172bbd6e2a435
 msgid "yes"
 msgstr "是"
-

--- a/xray.koplugin/main.lua
+++ b/xray.koplugin/main.lua
@@ -941,31 +941,21 @@ function XRayPlugin:getSubMenuItems()
                 sub_item_table = {
                     {
                         text = self.loc:t("menu_ui_popup_intext") or "Use Footnote Style for In-text Lookups",
-                        checked_func = function()
-                            local val = self.ai_helper and self.ai_helper.settings and self.ai_helper.settings.ui_popup_intext
-                            if val == nil then return true end
-                            return val
-                        end,
+                        checked_func = function() return self:settingEnabled("ui_popup_intext", true) end,
                         callback = function()
-                            if self.ai_helper and self.ai_helper.settings then
-                                local current = self.ai_helper.settings.ui_popup_intext
-                                if current == nil then current = true end
-                                self.ai_helper:saveSettings({ ui_popup_intext = not current })
+                            if self.ai_helper then
+                                self.ai_helper:saveSettings({ ui_popup_intext =
+                                    not self:settingEnabled("ui_popup_intext", true) })
                             end
                         end,
                     },
                     {
                         text = self.loc:t("menu_ui_popup_menu") or "Use Footnote Style for Menu Lookups",
-                        checked_func = function()
-                            local val = self.ai_helper and self.ai_helper.settings and self.ai_helper.settings.ui_popup_menu
-                            if val == nil then return false end
-                            return val
-                        end,
+                        checked_func = function() return self:settingEnabled("ui_popup_menu", false) end,
                         callback = function()
-                            if self.ai_helper and self.ai_helper.settings then
-                                local current = self.ai_helper.settings.ui_popup_menu
-                                if current == nil then current = false end
-                                self.ai_helper:saveSettings({ ui_popup_menu = not current })
+                            if self.ai_helper then
+                                self.ai_helper:saveSettings({ ui_popup_menu =
+                                    not self:settingEnabled("ui_popup_menu", false) })
                             end
                         end,
                     },
@@ -1043,7 +1033,7 @@ function XRayPlugin:getSubMenuItems()
                         sub_item_table = {
                             {
                                 text = self.loc:t("series_context_enabled_toggle") or "Enable Series Context",
-                                checked_func = function() return self.ai_helper.settings.series_context_enabled end,
+                                checked_func = function() return self:settingEnabled("series_context_enabled", false) end,
                                 callback = function() self:toggleSeriesContextEnabled() end,
                             },
                             {
@@ -1077,12 +1067,11 @@ function XRayPlugin:getSubMenuItems()
                 sub_item_table = {
                     {
                         text = self.loc:t("unit_conv_enabled") or "Enable Unit Converter",
-                        checked_func = function()
-                            return self.ai_helper.settings.unit_converter_enabled ~= false
-                        end,
+                        checked_func = function() return self:settingEnabled("unit_converter_enabled", true) end,
                         callback = function()
-                            local current = self.ai_helper.settings.unit_converter_enabled ~= false
-                            self.ai_helper:saveSettings({ unit_converter_enabled = not current })
+                            if not self.ai_helper then return end
+                            self.ai_helper:saveSettings({ unit_converter_enabled =
+                                not self:settingEnabled("unit_converter_enabled", true) })
                             if self.scanBookForUnits then self:scanBookForUnits() end
                         end
                     },
@@ -1135,66 +1124,60 @@ function XRayPlugin:getSubMenuItems()
                         sub_item_table = {
                             {
                                 text = "Length (mile, feet, inch, m, km...)",
-                                checked_func = function()
-                                    return self.ai_helper.settings.unit_cat_length ~= false
-                                end,
+                                checked_func = function() return self:settingEnabled("unit_cat_length", true) end,
                                 callback = function()
-                                    local curr = self.ai_helper.settings.unit_cat_length ~= false
+                                    if not self.ai_helper then return end
+                                    local curr = self:settingEnabled("unit_cat_length", true)
                                     self.ai_helper:saveSettings({ unit_cat_length = not curr })
                                     if self.scanBookForUnits then self:scanBookForUnits() end
                                 end
                             },
                             {
                                 text = "Weight / Mass (pound, ounce, kg, g...)",
-                                checked_func = function()
-                                    return self.ai_helper.settings.unit_cat_weight ~= false
-                                end,
+                                checked_func = function() return self:settingEnabled("unit_cat_weight", true) end,
                                 callback = function()
-                                    local curr = self.ai_helper.settings.unit_cat_weight ~= false
+                                    if not self.ai_helper then return end
+                                    local curr = self:settingEnabled("unit_cat_weight", true)
                                     self.ai_helper:saveSettings({ unit_cat_weight = not curr })
                                     if self.scanBookForUnits then self:scanBookForUnits() end
                                 end
                             },
                             {
                                 text = "Temperature (fahrenheit, celsius)",
-                                checked_func = function()
-                                    return self.ai_helper.settings.unit_cat_temp ~= false
-                                end,
+                                checked_func = function() return self:settingEnabled("unit_cat_temp", true) end,
                                 callback = function()
-                                    local curr = self.ai_helper.settings.unit_cat_temp ~= false
+                                    if not self.ai_helper then return end
+                                    local curr = self:settingEnabled("unit_cat_temp", true)
                                     self.ai_helper:saveSettings({ unit_cat_temp = not curr })
                                     if self.scanBookForUnits then self:scanBookForUnits() end
                                 end
                             },
                             {
                                 text = "Volume (gallon, cup, liter, ml...)",
-                                checked_func = function()
-                                    return self.ai_helper.settings.unit_cat_volume ~= false
-                                end,
+                                checked_func = function() return self:settingEnabled("unit_cat_volume", true) end,
                                 callback = function()
-                                    local curr = self.ai_helper.settings.unit_cat_volume ~= false
+                                    if not self.ai_helper then return end
+                                    local curr = self:settingEnabled("unit_cat_volume", true)
                                     self.ai_helper:saveSettings({ unit_cat_volume = not curr })
                                     if self.scanBookForUnits then self:scanBookForUnits() end
                                 end
                             },
                             {
                                 text = "Speed (mph, km/h)",
-                                checked_func = function()
-                                    return self.ai_helper.settings.unit_cat_speed ~= false
-                                end,
+                                checked_func = function() return self:settingEnabled("unit_cat_speed", true) end,
                                 callback = function()
-                                    local curr = self.ai_helper.settings.unit_cat_speed ~= false
+                                    if not self.ai_helper then return end
+                                    local curr = self:settingEnabled("unit_cat_speed", true)
                                     self.ai_helper:saveSettings({ unit_cat_speed = not curr })
                                     if self.scanBookForUnits then self:scanBookForUnits() end
                                 end
                             },
                             {
                                 text = "Area (acre, hectare, m², sq ft...)",
-                                checked_func = function()
-                                    return self.ai_helper.settings.unit_cat_area ~= false
-                                end,
+                                checked_func = function() return self:settingEnabled("unit_cat_area", true) end,
                                 callback = function()
-                                    local curr = self.ai_helper.settings.unit_cat_area ~= false
+                                    if not self.ai_helper then return end
+                                    local curr = self:settingEnabled("unit_cat_area", true)
                                     self.ai_helper:saveSettings({ unit_cat_area = not curr })
                                     if self.scanBookForUnits then self:scanBookForUnits() end
                                 end
@@ -2662,7 +2645,9 @@ function XRayPlugin:getBookTypeFilterMenu()
                     table.insert(opts, {
                         text = bt.text,
                         checked_func = function()
-                            local disabled = self.ai_helper.settings.unit_disabled_book_types or { "manga", "graphic_novel", "children", "poetry" }
+                            local settings = self.ai_helper and self.ai_helper.settings
+                            local disabled = (settings and settings.unit_disabled_book_types)
+                                or { "manga", "graphic_novel", "children", "poetry" }
                             local disabled_map = {}
                             for _, k in ipairs(disabled) do disabled_map[k] = true end
                             return not disabled_map[bt.key]

--- a/xray.koplugin/main.lua
+++ b/xray.koplugin/main.lua
@@ -940,6 +940,19 @@ function XRayPlugin:getSubMenuItems()
                 keep_menu_open = true,
                 sub_item_table = {
                     {
+                        text = self.loc:t("menu_timeline_presence_map") or "Use Presence Map in Timeline",
+                        checked_func = function() return self:presenceMapEnabled() end,
+                        callback = function()
+                            if self.ai_helper and self.ai_helper.settings then
+                                self.ai_helper:saveSettings({
+                                    timeline_presence_map = not self:presenceMapEnabled() })
+                                -- Rebuild if the Timeline is open behind this menu.
+                                if self.timeline_view then self:showTimeline() end
+                            end
+                        end,
+                        separator = true,
+                    },
+                    {
                         text = self.loc:t("menu_ui_popup_intext") or "Use Footnote Style for In-text Lookups",
                         checked_func = function() return self:settingEnabled("ui_popup_intext", true) end,
                         callback = function()

--- a/xray.koplugin/xray_presencemap.lua
+++ b/xray.koplugin/xray_presencemap.lua
@@ -20,12 +20,32 @@ local function isWordByte(b)
         b == BYTE_UNDERSCORE)
 end
 
--- Lower-cased once per call rather than per chapter.
-local function needlesFor(character)
-    local needles = {}
+-- Whether the AI labelled this character a lead. The role field is free text,
+-- so this is a hint, never a ranking.
+local function isLead(role)
+    return type(role) == "string" and role:lower():find("protagonist", 1, true) ~= nil
+end
+
+-- The last word of a multi-word name. Prose leans on surnames ("Holden's crew")
+-- and the AI's alias list often omits them. Short ones collide too often to
+-- guess from, so they are skipped, as in xray_data's frequency scorer.
+local function surnameOf(name)
+    if type(name) ~= "string" then return nil end
+    local last = name:match("(%S+)$")
+    if last and #last > 3 and last ~= name then return last end
+    return nil
+end
+
+-- Lower-cased once per call rather than per chapter. Duplicates are dropped:
+-- an alias that repeats the canonical name or the surname would otherwise buy a
+-- second scan of every chapter for an answer the first scan already gave.
+local function needlesFor(character, own_surname)
+    local needles, seen = {}, {}
     local function add(text)
         if type(text) ~= "string" or text == "" then return end
         local lowered = text:lower()
+        if seen[lowered] then return end
+        seen[lowered] = true
         needles[#needles + 1] = {
             text = lowered,
             starts_word = isWordByte(lowered:byte(1)),
@@ -34,6 +54,7 @@ local function needlesFor(character)
     end
     add(character.name)
     for _, alias in ipairs(character.aliases or {}) do add(alias) end
+    add(own_surname)
     return needles
 end
 
@@ -60,10 +81,25 @@ end
 -- Both the chapter title and the summary are searched.
 function M.buildPresenceMatrix(events, characters)
     -- The name is this matrix's key, so a nameless entry is skipped.
+    -- A surname shared by two characters identifies neither, so it is only a
+    -- needle when one character owns it.
+    local surnames, owners = {}, {}
+    for i, character in ipairs(characters or {}) do
+        local surname = surnameOf(character.name)
+        surnames[i] = surname
+        if surname then
+            local key = surname:lower()
+            owners[key] = (owners[key] or 0) + 1
+        end
+    end
+
     local needles = {}
-    for _, character in ipairs(characters or {}) do
+    for i, character in ipairs(characters or {}) do
         if type(character.name) == "string" and character.name ~= "" then
-            needles[#needles + 1] = { name = character.name, list = needlesFor(character) }
+            local surname = surnames[i]
+            if surname and owners[surname:lower()] ~= 1 then surname = nil end
+            needles[#needles + 1] =
+                { name = character.name, list = needlesFor(character, surname) }
         end
     end
 
@@ -95,21 +131,44 @@ local MIN_FILTERED_ROWS = 3
 -- min_coverage drops walk-ons named in fewer than that many chapters, and
 -- defaults to 1, which keeps everyone. It is ignored when fewer than
 -- MIN_FILTERED_ROWS characters would survive: early in a book almost everyone
--- appears once, and an empty map is worse than a crowded one.
+-- appears once, and an empty map is worse than a crowded one. A lead is kept
+-- either way, since appearing in one fetched chapter does not make them minor.
 function M.coverageOrder(matrix, characters, min_coverage)
-    local stats = {}
+    -- Keyed by name, matching the matrix, so two entries sharing one name draw
+    -- one row rather than two identical ones. The same non-empty-string check
+    -- as buildPresenceMatrix, so a nameless AI entry is skipped by both.
+    -- lead is the union across those entries: the role sits on whichever one
+    -- the AI wrote it on, and taking only the first would drop a protagonist
+    -- the rule below is meant to keep.
+    local by_name, entries = {}, {}
     for _, character in ipairs(characters or {}) do
         local name = character.name
-        local coverage, first = 0, nil
-        for row = 1, #matrix do
-            if matrix[row] and matrix[row][name] then
-                coverage = coverage + 1
-                first = first or row
+        if type(name) == "string" and name ~= "" then
+            local entry = by_name[name]
+            if not entry then
+                entry = { name = name, coverage = 0, first = nil, lead = false }
+                by_name[name] = entry
+                entries[#entries + 1] = entry
+            end
+            if isLead(character.role) then entry.lead = true end
+        end
+    end
+
+    -- One pass over the matrix rather than a rescan per character. Rows are
+    -- visited in order, so the first row to name someone is their first.
+    for row = 1, #matrix do
+        for name in pairs(matrix[row] or {}) do
+            local entry = by_name[name]
+            if entry then
+                entry.coverage = entry.coverage + 1
+                entry.first = entry.first or row
             end
         end
-        if coverage > 0 then
-            stats[#stats + 1] = { name = name, coverage = coverage, first = first }
-        end
+    end
+
+    local stats = {}
+    for _, entry in ipairs(entries) do
+        if entry.coverage > 0 then stats[#stats + 1] = entry end
     end
 
     table.sort(stats, function(a, b)
@@ -121,7 +180,9 @@ function M.coverageOrder(matrix, characters, min_coverage)
     local order, kept = {}, {}
     for i, entry in ipairs(stats) do
         order[i] = entry.name
-        if entry.coverage >= (min_coverage or 1) then kept[#kept + 1] = entry.name end
+        if entry.coverage >= (min_coverage or 1) or entry.lead then
+            kept[#kept + 1] = entry.name
+        end
     end
     if #kept >= MIN_FILTERED_ROWS then return kept end
     return order
@@ -156,6 +217,9 @@ end
 -- never happened.
 function M.bucketMatrix(matrix, chapter_matches, n_buckets)
     local nrows = #matrix
+    -- No chapters means no columns. The clamp below floors the count at one,
+    -- which would otherwise invent a bucket spanning a chapter that is not there.
+    if nrows == 0 then return {}, {}, {} end
     n_buckets = math.max(1, math.min(n_buckets or nrows, nrows))
 
     local matched_row = {}

--- a/xray.koplugin/xray_presencemap.lua
+++ b/xray.koplugin/xray_presencemap.lua
@@ -84,11 +84,19 @@ function M.buildPresenceMatrix(events, characters)
     return matrix
 end
 
+-- Below this many characters, min_coverage is ignored. See coverageOrder.
+local MIN_FILTERED_ROWS = 3
+
 -- Characters that appear at all, most-present first. Shared by the filter
 -- buttons, name gutter and grid rows, so a position always means the same
 -- character. Ties break by first appearance then name, so the order does not
 -- shuffle between rebuilds.
-function M.coverageOrder(matrix, characters)
+--
+-- min_coverage drops walk-ons named in fewer than that many chapters, and
+-- defaults to 1, which keeps everyone. It is ignored when fewer than
+-- MIN_FILTERED_ROWS characters would survive: early in a book almost everyone
+-- appears once, and an empty map is worse than a crowded one.
+function M.coverageOrder(matrix, characters, min_coverage)
     local stats = {}
     for _, character in ipairs(characters or {}) do
         local name = character.name
@@ -110,8 +118,12 @@ function M.coverageOrder(matrix, characters)
         return a.name < b.name
     end)
 
-    local order = {}
-    for i, entry in ipairs(stats) do order[i] = entry.name end
+    local order, kept = {}, {}
+    for i, entry in ipairs(stats) do
+        order[i] = entry.name
+        if entry.coverage >= (min_coverage or 1) then kept[#kept + 1] = entry.name end
+    end
+    if #kept >= MIN_FILTERED_ROWS then return kept end
     return order
 end
 

--- a/xray.koplugin/xray_presencemap.lua
+++ b/xray.koplugin/xray_presencemap.lua
@@ -1,0 +1,279 @@
+-- Timeline presence map: pure layout logic, no UI dependencies.
+-- Stateless, so M.name() not M:name(). Required directly, like xray_theme.
+-- Name matching duplicates ChapterAnalyzer:findCharactersInText and is
+-- case-insensitive to agree with it. No dependencies, so the spec can run
+-- outside KOReader.
+local M = {}
+
+local BYTE_0, BYTE_9 = string.byte("0"), string.byte("9")
+local BYTE_A, BYTE_Z = string.byte("A"), string.byte("Z")
+local BYTE_a, BYTE_z = string.byte("a"), string.byte("z")
+local BYTE_UNDERSCORE = string.byte("_")
+
+-- ASCII only. CJK bytes are never word characters, so the boundary checks
+-- always pass and matching falls back to plain substring search.
+local function isWordByte(b)
+    return b ~= nil and (
+        (b >= BYTE_0 and b <= BYTE_9) or
+        (b >= BYTE_A and b <= BYTE_Z) or
+        (b >= BYTE_a and b <= BYTE_z) or
+        b == BYTE_UNDERSCORE)
+end
+
+-- Lower-cased once per call rather than per chapter.
+local function needlesFor(character)
+    local needles = {}
+    local function add(text)
+        if type(text) ~= "string" or text == "" then return end
+        local lowered = text:lower()
+        needles[#needles + 1] = {
+            text = lowered,
+            starts_word = isWordByte(lowered:byte(1)),
+            ends_word = isWordByte(lowered:byte(#lowered)),
+        }
+    end
+    add(character.name)
+    for _, alias in ipairs(character.aliases or {}) do add(alias) end
+    return needles
+end
+
+-- Plain find, not a pattern, so names with metacharacters need no escaping.
+-- Only an end that is itself a word character needs a boundary check, so a
+-- name ending in ")" still matches.
+local function containsNeedle(text, needle)
+    local from = 1
+    local len = #text
+    while true do
+        local s, e = text:find(needle.text, from, true)
+        if not s then return false end
+        local ok_before = not needle.starts_word or not isWordByte(text:byte(s - 1))
+        local ok_after = not needle.ends_word or
+            (e >= len or not isWordByte(text:byte(e + 1)))
+        if ok_before and ok_after then return true end
+        from = s + 1
+    end
+end
+
+-- Which tracked characters are named in each event.
+-- Returns matrix[row][character_name] = true.
+-- The caller supplies already-filtered events, so row N is its event N.
+-- Both the chapter title and the summary are searched.
+function M.buildPresenceMatrix(events, characters)
+    -- The name is this matrix's key, so a nameless entry is skipped.
+    local needles = {}
+    for _, character in ipairs(characters or {}) do
+        if type(character.name) == "string" and character.name ~= "" then
+            needles[#needles + 1] = { name = character.name, list = needlesFor(character) }
+        end
+    end
+
+    local matrix = {}
+    for row, entry in ipairs(events or {}) do
+        local cell = {}
+        local text = ((entry.chapter or "") .. "\n" .. (entry.event or "")):lower()
+        for _, character in ipairs(needles) do
+            for _, needle in ipairs(character.list) do
+                if containsNeedle(text, needle) then
+                    cell[character.name] = true
+                    break
+                end
+            end
+        end
+        matrix[row] = cell
+    end
+    return matrix
+end
+
+-- Characters that appear at all, most-present first. Shared by the filter
+-- buttons, name gutter and grid rows, so a position always means the same
+-- character. Ties break by first appearance then name, so the order does not
+-- shuffle between rebuilds.
+function M.coverageOrder(matrix, characters)
+    local stats = {}
+    for _, character in ipairs(characters or {}) do
+        local name = character.name
+        local coverage, first = 0, nil
+        for row = 1, #matrix do
+            if matrix[row] and matrix[row][name] then
+                coverage = coverage + 1
+                first = first or row
+            end
+        end
+        if coverage > 0 then
+            stats[#stats + 1] = { name = name, coverage = coverage, first = first }
+        end
+    end
+
+    table.sort(stats, function(a, b)
+        if a.coverage ~= b.coverage then return a.coverage > b.coverage end
+        if a.first ~= b.first then return a.first < b.first end
+        return a.name < b.name
+    end)
+
+    local order = {}
+    for i, entry in ipairs(stats) do order[i] = entry.name end
+    return order
+end
+
+-- Ascending row indices where every selected character is present.
+-- An empty selection means all rows.
+function M.matchingChapters(matrix, selected)
+    local out = {}
+    for row = 1, #matrix do
+        local all_present = true
+        for _, name in ipairs(selected or {}) do
+            if not (matrix[row] and matrix[row][name]) then
+                all_present = false
+                break
+            end
+        end
+        if all_present then out[#out + 1] = row end
+    end
+    return out
+end
+
+-- Collapse a chapter-level matrix into at most n_buckets columns, so a long
+-- book fits the screen without scrolling sideways.
+-- chapter_matches is the row list from matchingChapters.
+-- Returns the bucketed matrix, the matching bucket indices, and the ranges.
+--
+-- Presence can be bucketed, but crossings cannot. That is why this takes an
+-- already resolved list of matching chapters rather than a selection.
+-- Two characters in different chapters of one span have not met, so working
+-- the crossings out from the bucketed matrix would report a meeting that
+-- never happened.
+function M.bucketMatrix(matrix, chapter_matches, n_buckets)
+    local nrows = #matrix
+    n_buckets = math.max(1, math.min(n_buckets or nrows, nrows))
+
+    local matched_row = {}
+    for _, idx in ipairs(chapter_matches or {}) do matched_row[idx] = true end
+
+    local buckets, matches, ranges = {}, {}, {}
+    for b = 1, n_buckets do
+        -- Spread any remainder evenly rather than piling it into the last span.
+        local first = math.floor((b - 1) * nrows / n_buckets) + 1
+        local last = math.floor(b * nrows / n_buckets)
+        if last < first then last = first end
+        ranges[b] = { first = first, last = last }
+
+        local cell, crossed = {}, false
+        for row = first, last do
+            for name in pairs(matrix[row] or {}) do cell[name] = true end
+            if matched_row[row] then crossed = true end
+        end
+        buckets[b] = cell
+        if crossed then matches[#matches + 1] = b end
+    end
+
+    return buckets, matches, ranges
+end
+
+-- Which characters get a row: the selection, or everyone when unfiltered.
+-- Shared with the UI's height calculation so the two cannot disagree.
+function M.shownNames(order, selected)
+    if not selected or #selected == 0 then return order end
+    local is_selected = {}
+    for _, name in ipairs(selected) do is_selected[name] = true end
+    local rows = {}
+    for _, name in ipairs(order) do
+        if is_selected[name] then rows[#rows + 1] = name end
+    end
+    return rows
+end
+
+-- Pixel height of a strip with this many character rows. Exported so the UI's
+-- scroll cap cannot drift from what the renderers draw.
+function M.stripHeight(n_rows, geom)
+    return geom.top_padding + n_rows * geom.row_height + 4
+end
+
+local XML_ESCAPES = { ["&"] = "&amp;", ["<"] = "&lt;", [">"] = "&gt;", ['"'] = "&quot;" }
+
+local function xmlEscape(text)
+    return (tostring(text):gsub('[&<>"]', XML_ESCAPES))
+end
+
+local function svgOpen(w, h)
+    return {
+        string.format(
+            '<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="%d" viewBox="0 0 %d %d">',
+            w, h, w, h),
+        string.format('<rect class="bg" x="0" y="0" width="%d" height="%d" fill="white"/>', w, h),
+    }
+end
+
+-- The left gutter: one name per row. Split from the grid so it stays put while
+-- the grid scrolls. Returns svg, width, height.
+function M.buildStripNamesSVG(order, selected, geom)
+    local rows = M.shownNames(order, selected)
+    local width, height = geom.name_width, M.stripHeight(#rows, geom)
+    local out = svgOpen(width, height)
+    for r, name in ipairs(rows) do
+        local y = geom.top_padding + (r - 1) * geom.row_height + geom.row_height / 2
+        out[#out + 1] = string.format(
+            '<text class="cname" x="%.1f" y="%.1f" font-size="%d" text-anchor="end" fill="black">%s</text>',
+            width - 7, y + 3, geom.label_size + 2, xmlEscape(name))
+    end
+    out[#out + 1] = "</svg>"
+    return table.concat(out, "\n"), width, height
+end
+
+-- The grid: columns as chapters (or bucketed spans), one row per shown name.
+-- Returns svg, width, height.
+--
+-- Every column is kept while filtering, to show where in the book the matches
+-- fall. Matching columns are shaded. Two or more selections draw a join line,
+-- which is safe because only selected characters have rows here.
+--
+-- match_cols must be passed in. A bucketed matrix has already lost the
+-- per-chapter detail, so the crossings cannot be worked out here.
+function M.buildStripGridSVG(matrix, order, chapters, selected, geom, match_cols)
+    local rows = M.shownNames(order, selected)
+    local filtering = selected and #selected > 0
+
+    local matches = {}
+    for _, idx in ipairs(match_cols or {}) do matches[idx] = true end
+
+    local ncols = #chapters
+    local width, height = ncols * geom.col_width, M.stripHeight(#rows, geom)
+    local out = svgOpen(width, height)
+
+    local function colX(i) return (i - 1) * geom.col_width + geom.col_width / 2 end
+    local function rowY(r)
+        return geom.top_padding + (r - 1) * geom.row_height + geom.row_height / 2
+    end
+
+    if filtering then
+        local join = #rows >= 2
+        for i = 1, ncols do
+            if matches[i] then
+                out[#out + 1] = string.format(
+                    '<rect class="shade" x="%.1f" y="%.1f" width="%d" height="%.1f" fill="#e3e6df"/>',
+                    colX(i) - geom.col_width / 2, geom.top_padding - 4,
+                    geom.col_width, #rows * geom.row_height + 4)
+                if join then
+                    out[#out + 1] = string.format(
+                        '<line class="join" x1="%.1f" y1="%.1f" x2="%.1f" y2="%.1f" stroke="black" stroke-width="2"/>',
+                        colX(i), rowY(1), colX(i), rowY(#rows))
+                end
+            end
+        end
+    end
+
+    for r, name in ipairs(rows) do
+        for i = 1, ncols do
+            if matrix[i] and matrix[i][name] then
+                out[#out + 1] = string.format(
+                    '<rect class="pip" x="%.1f" y="%.1f" width="%d" height="%d" fill="black"/>',
+                    colX(i) - geom.marker / 2, rowY(r) - geom.marker / 2,
+                    geom.marker, geom.marker)
+            end
+        end
+    end
+
+    out[#out + 1] = "</svg>"
+    return table.concat(out, "\n"), width, height
+end
+
+return M

--- a/xray.koplugin/xray_ui.lua
+++ b/xray.koplugin/xray_ui.lua
@@ -3577,6 +3577,56 @@ local function _buildTimelineHeader(self, ctx)
         end
     end
 
+    -- Sort direction and the two jumps, in a fixed band of their own rather than
+    -- folded into the filter block: that block scrolls away once the cast passes
+    -- BUTTON_VISIBLE_ROWS, which is exactly when the sort state matters most.
+    -- Hidden when the list is empty, so controls are never offered for nothing.
+    if not ctx.empty_text and ctx.on_sort_toggle then
+        -- Capped at a quarter of the usable width so the label between them can
+        -- never be squeezed to nothing, or past it, on a narrow screen.
+        local jump_w = math.min(Screen:scaleBySize(46), math.floor((sw - pad * 2) / 4))
+        local sort_w = sw - pad * 2 - jump_w * 2
+        local icon_px = Screen:scaleBySize(18)
+        -- KOReader's own first/last-page chevrons rather than a glyph: the
+        -- corner arrows that would say this in text sit outside the UI font and
+        -- would render as tofu, while an icon has no font dependency at all.
+        local function jump(icon, callback)
+            return Button:new{
+                icon = icon,
+                icon_width = icon_px,
+                icon_height = icon_px,
+                width = jump_w,
+                bordersize = 0,
+                background = xray_theme.color_bg,
+                show_parent = ctx.show_parent,
+                callback = callback,
+            }
+        end
+        -- The label names the current state, not what a tap would do, so the
+        -- arrow and the words always agree. U+2191/2193 come from the same
+        -- block as the arrows this plugin already draws elsewhere.
+        table.insert(components, HorizontalGroup:new{
+            align = "center",
+            HorizontalSpan:new{ width = pad },
+            jump("chevron.first",
+                 function() if ctx.on_jump then ctx.on_jump("top") end end),
+            Button:new{
+                text = (ctx.sort_desc and "\u{2193} " or "\u{2191} ") .. (ctx.sort_label or ""),
+                width = sort_w,
+                max_width = sort_w,
+                align = "center",
+                bordersize = 0,
+                background = xray_theme.color_bg,
+                text_font_size = 14,
+                show_parent = ctx.show_parent,
+                callback = ctx.on_sort_toggle,
+            },
+            jump("chevron.last",
+                 function() if ctx.on_jump then ctx.on_jump("bottom") end end),
+        })
+        table.insert(components, VerticalSpan:new{ width = pad })
+    end
+
     -- Earlier books in the series, in a scroller of their own so a long series
     -- cannot push this book's chapters off the screen.
     -- The caller builds the list only when the block is open, so a list here
@@ -3679,6 +3729,7 @@ function XRayTimelineView:init()
         show_parent = self,
         self.rows,
     }
+    self.body = body
     -- UIManager crops repaints to one registered scrollable per screen, and only
     -- the body is registered. Known consequence: a pan starting in the chapter
     -- list that crosses into the header band can be claimed by the wrong container.
@@ -3694,6 +3745,22 @@ function XRayTimelineView:init()
             body,
         },
     }
+end
+
+-- Scroll the chapter list to one end. The list holds only the chapters matching
+-- the current filter, so its ends already are the first and last match and no
+-- index mapping is needed. Reversing the sort reverses the list, so "top" keeps
+-- meaning the first row drawn rather than the earliest chapter.
+--
+-- scrollToRatio, not setScrolledOffset: the latter only assigns the offset and
+-- leaves the scrollbar thumb where it was. scrollToRatio finishes with
+-- _scrollBy(0, 0), which clamps against the container's own crop height --
+-- narrower than dimen.h, since the scrollbar takes width -- then updates the
+-- thumb and repaints. It centres on the ratio, so 0 and 1 clamp to exactly the
+-- top and bottom.
+function XRayTimelineView:jumpRowsTo(where)
+    if not self.body or not self.body.scrollToRatio then return end
+    self.body:scrollToRatio(nil, (where == "bottom") and 1 or 0)
 end
 
 function XRayTimelineView:onClose()
@@ -3944,6 +4011,21 @@ local function _timelineData(self)
     return cache
 end
 
+-- The current book's chapter rows in display order.
+--
+-- Returns a copy when reversing: the caller's list comes from the timeline
+-- cache and is reused across filter taps, so reversing it in place would flip
+-- it again on the next rebuild and the order would alternate as you tapped.
+--
+-- Prior-book rows are not passed through here. They belong to earlier books and
+-- stay above the current book whichever way this one is sorted.
+function M:timelineRowSpecs(specs, descending)
+    if not descending then return specs end
+    local out = {}
+    for i = #specs, 1, -1 do out[#out + 1] = specs[i] end
+    return out
+end
+
 -- One row per earlier book in the series, or nil when the block is hidden.
 --
 -- A character filter hides them: prior events are not in the presence matrix,
@@ -3977,6 +4059,12 @@ function M:showTimeline()
     self.timeline_filter = self.timeline_filter or {}
     local filtering = #self.timeline_filter > 0
 
+    -- Sort direction sits beside the filter and deliberately outside the
+    -- _timelineData cache. Reversing is a display concern: the matrix and the
+    -- coverage order the cache holds are the same either way, so keying on it
+    -- would rebuild assignTimelinePages on every tap for no change.
+    if self.timeline_sort_desc == nil then self.timeline_sort_desc = false end
+
     -- Closed on first open, so the chapter list stays visible.
     if self.series_prior_timeline_collapsed == nil then
         self.series_prior_timeline_collapsed = true
@@ -4003,6 +4091,7 @@ function M:showTimeline()
             row_specs[#row_specs + 1] = { chapter = ev.chapter or "", event = ev.event or "", ev = ev }
         end
     end
+    row_specs = self:timelineRowSpecs(row_specs, self.timeline_sort_desc)
 
     -- When a filter matches nothing the list stays empty and the message is
     -- drawn in the header, where it can be centered and has no row border.
@@ -4033,6 +4122,20 @@ function M:showTimeline()
         show_map = show_map,
         prior_specs = prior_specs,
         prior_label = self.loc:t("series_prior_books_header") or "── Prior Books ──",
+        sort_desc = self.timeline_sort_desc,
+        sort_label = self.timeline_sort_desc
+            and (self.loc:t("timeline_sort_newest") or "Newest first")
+            or (self.loc:t("timeline_sort_oldest") or "Oldest first"),
+        on_sort_toggle = function()
+            self.timeline_sort_desc = not self.timeline_sort_desc
+            self:showTimeline()
+        end,
+        -- The chapter list belongs to the view, which does not exist while this
+        -- table is being built. By the time a button can be tapped, it does.
+        on_jump = function(where)
+            local view = self.timeline_view
+            if view and view.jumpRowsTo then view:jumpRowsTo(where) end
+        end,
         on_prior_toggle = function()
             self.series_prior_timeline_collapsed = not self.series_prior_timeline_collapsed
             self:showTimeline()

--- a/xray.koplugin/xray_ui.lua
+++ b/xray.koplugin/xray_ui.lua
@@ -3872,13 +3872,31 @@ end
 -- expensive. assignTimelinePages runs full-document findText scans for chapter
 -- titles that miss the TOC, which would cost seconds on every filter tap.
 -- Identity alone is not enough: merges and "fetch more characters" mutate
--- self.characters in place, so the name list is compared as well.
+-- self.characters in place, so every field the map reads is compared as well.
+-- That is the name and aliases, which decide presence, and the role, which
+-- decides whether coverageOrder keeps a lead below the minimum. Aliases only
+-- ever grow and a role change today arrives with a fresh self.timeline, so this
+-- guards an invariant rather than a live staleness bug -- but the invariant is
+-- then local to this function instead of resting on what the callers happen to
+-- do.
+--
+-- Length-prefixed, so no name or alias can spell out a separator and pass
+-- itself off as a different field boundary.
+local function _field(parts, value)
+    local text = tostring(value)
+    parts[#parts + 1] = #text .. ":" .. text
+end
+
 local function _charactersSignature(characters)
-    local names = {}
-    for i, c in ipairs(characters or {}) do
-        names[i] = tostring(c.name) .. "/" .. tostring(#(c.aliases or {}))
+    local parts = {}
+    for _, c in ipairs(characters or {}) do
+        _field(parts, c.name)
+        _field(parts, c.role)
+        local aliases = c.aliases or {}
+        _field(parts, #aliases)
+        for _, alias in ipairs(aliases) do _field(parts, alias) end
     end
-    return table.concat(names, "\30")
+    return table.concat(parts, "\30")
 end
 
 local function _timelineData(self)

--- a/xray.koplugin/xray_ui.lua
+++ b/xray.koplugin/xray_ui.lua
@@ -3386,6 +3386,7 @@ local HEADER_IGNORED_GESTURES = {
 local STRIP_VISIBLE_ROWS = 3   -- character rows in the presence chart
 local BUTTON_VISIBLE_ROWS = 2  -- rows of filter buttons (3 buttons per row)
 local PRIOR_VISIBLE_ROWS = 2   -- earlier books shown before the recap block scrolls
+local MIN_CHAPTER_COVERAGE = 2 -- a character in fewer chapters is a walk-on
 
 -- Restore a scroll position across a rebuild.
 -- A filter change can leave less to scroll, so the saved offset is clamped to
@@ -3498,7 +3499,7 @@ local function _buildTimelineHeader(self, ctx)
     table.insert(components, VerticalSpan:new{ width = pad })
 
     local ncols = #ctx.chapters
-    if ncols > 0 and ctx.show_map then
+    if ncols > 0 and ctx.show_map and #presence.shownNames(ctx.order, ctx.selected) > 0 then
         local RenderImage = require("ui/renderimage")
         local ImageWidget = require("ui/widget/imagewidget")
 
@@ -3919,7 +3920,7 @@ local function _timelineData(self)
         chapter_titles = chapter_titles,
         prior_events = prior_events,
         matrix = matrix,
-        order = presence.coverageOrder(matrix, characters),
+        order = presence.coverageOrder(matrix, characters, MIN_CHAPTER_COVERAGE),
     }
     self._timeline_cache = cache
     return cache

--- a/xray.koplugin/xray_ui.lua
+++ b/xray.koplugin/xray_ui.lua
@@ -667,7 +667,7 @@ function M:isRTL()
 end
 
 function M:isXRayUIActive()
-    return self._menu_creating or self.xray_menu or self.char_menu or self.loc_menu or self.timeline_menu 
+    return self._menu_creating or self.xray_menu or self.char_menu or self.loc_menu or self.timeline_view 
         or self.hf_menu or self.terms_menu or self.ldlg or self.active_related_menu or self.length_presets_menu
 end
 
@@ -840,14 +840,14 @@ function M:closeAllMenus()
     -- 1. Close all custom plugin modals instantly
     local menus = {
         self.mentions_menu, self.char_menu, self.loc_menu,
-        self.timeline_menu, self.hf_menu, self.xray_menu,
+        self.timeline_view, self.hf_menu, self.xray_menu,
         self.terms_menu, self.active_details_dialog, self.return_banner
     }
     for i = 1, 9 do
         if menus[i] then pcall(function() UIManager:close(menus[i]) end) end
     end
     self.mentions_menu = nil; self.char_menu = nil; self.loc_menu = nil
-    self.timeline_menu = nil; self.hf_menu = nil; self.xray_menu = nil
+    self.timeline_view = nil; self.hf_menu = nil; self.xray_menu = nil
     self.terms_menu = nil; self.active_details_dialog = nil; self.return_banner = nil
     
     local function executeClear()
@@ -3835,78 +3835,185 @@ end
 -- titles that miss the TOC, which would cost seconds on every filter tap.
 -- Identity alone is not enough: merges and "fetch more characters" mutate
 -- self.characters in place, so the name list is compared as well.
-function M:showTimeline()
-    if not self.timeline or #self.timeline == 0 then UIManager:show(InfoMessage:new{ text = self.loc:t("no_timeline_data"), timeout = 3 }); return end
+local function _charactersSignature(characters)
+    local names = {}
+    for i, c in ipairs(characters or {}) do
+        names[i] = tostring(c.name) .. "/" .. tostring(#(c.aliases or {}))
+    end
+    return table.concat(names, "\30")
+end
+
+local function _timelineData(self)
+    local signature = _charactersSignature(self.characters)
+    local cache = self._timeline_cache
+    if cache and cache.timeline == self.timeline
+            and cache.characters == self.characters
+            and cache.signature == signature then
+        return cache
+    end
+
     local utils = require(plugin_path .. "xray_utils")
+    local presence = require(plugin_path .. "xray_presencemap")
     local toc = utils:flattenTOC(self.ui.document:getToc())
+    -- Both mutate self.timeline in place, so its identity stays stable.
     self:assignTimelinePages(self.timeline, toc, true)
     self:sortTimelineByTOC(self.timeline)
-    
-    local has_prior = false
+
+    -- Matrix rows line up with current-book events only, in the same order, so
+    -- index i means the same in both.
+    local events, chapter_titles = {}, {}
     for _, ev in ipairs(self.timeline) do
-        if ev.source == "series_prior" then
-            has_prior = true
-            break
+        if ev.source ~= "series_prior" then
+            events[#events + 1] = ev
+            chapter_titles[#chapter_titles + 1] = ev.chapter or ""
         end
     end
 
-    if self.series_prior_timeline_collapsed == nil then
-        self.series_prior_timeline_collapsed = true
+    local characters = self.characters or {}
+    local matrix = presence.buildPresenceMatrix(events, characters)
+    cache = {
+        timeline = self.timeline,
+        characters = self.characters,
+        signature = signature,
+        events = events,
+        chapter_titles = chapter_titles,
+        matrix = matrix,
+        order = presence.coverageOrder(matrix, characters),
+    }
+    self._timeline_cache = cache
+    return cache
+end
+
+-- Whether the timeline shows its presence map. Unset means on.
+function M:presenceMapEnabled()
+    return self:settingEnabled("timeline_presence_map", true)
+end
+
+function M:showTimeline()
+    if not self.timeline or #self.timeline == 0 then UIManager:show(InfoMessage:new{ text = self.loc:t("no_timeline_data"), timeout = 3 }); return end
+    local presence = require(plugin_path .. "xray_presencemap")
+    local data = _timelineData(self)
+
+    -- Character filter state lives on the plugin so a rebuild preserves it.
+    local show_map = self:presenceMapEnabled()
+    self.timeline_filter = self.timeline_filter or {}
+    local filtering = #self.timeline_filter > 0
+
+
+    -- The header is rebuilt on every filter tap, so scroll positions are carried
+    -- across. A position is kept even when its scroller disappears: filtering to
+    -- one character collapses the map, and it should reopen where it was.
+    local scroll_state = self._timeline_scroll_state or {}
+    for key, sc in pairs(self._timeline_scrollers or {}) do
+        if sc.getScrolledOffset then scroll_state[key] = sc:getScrolledOffset() end
+    end
+    self._timeline_scroll_state = scroll_state
+    self._timeline_scrollers = {}
+
+    local matches = presence.matchingChapters(data.matrix, self.timeline_filter)
+    local is_match = {}
+    for _, idx in ipairs(matches) do is_match[idx] = true end
+
+    local row_specs = {}
+    for i, ev in ipairs(data.events) do
+        if is_match[i] then
+            row_specs[#row_specs + 1] = { chapter = ev.chapter or "", event = ev.event or "", ev = ev }
+        end
     end
 
-    local items = {}
-    if has_prior then
-        local arrow = self.series_prior_timeline_collapsed and "► " or "▼ "
-        local header_text = arrow .. (self.loc:t("series_prior_books_header") or "── Prior Books ──")
-        table.insert(items, {
-            text = header_text,
-            keep_menu_open = true,
-            callback = function()
-                self.series_prior_timeline_collapsed = not self.series_prior_timeline_collapsed
-                self:showTimeline()
-            end
-        })
-    end
-
-    for _, ev in ipairs(self.timeline) do
-        if ev.source == "series_prior" then
-            if not self.series_prior_timeline_collapsed then
-                table.insert(items, {
-                    text = ev.chapter or "",
-                    keep_menu_open = true,
-                    callback = function()
-                        self:showTimelineEventDetails(ev, { source = "menu" })
-                    end
-                })
-            end
+    -- When a filter matches nothing the list stays empty and the message is
+    -- drawn in the header, where it can be centered and has no row border.
+    local all_label = self.loc:t("menu_timeline_all") or "All"
+    local empty_text = nil
+    if #row_specs == 0 then
+        if filtering then
+            empty_text = self.loc:t("timeline_no_shared_chapters",
+                table.concat(self.timeline_filter, " \u{00B7} "), all_label)
         else
-            table.insert(items, {
-                text = (ev.chapter or "") .. ": " .. (ev.event or ""),
-                keep_menu_open = true,
-                callback = function()
-                    self:showTimelineEventDetails(ev, { source = "menu" })
-                end
-            })
+            -- Not an empty timeline (caught above) but nothing for this book:
+            -- everything held is from earlier books in a series.
+            empty_text = self.loc:t("no_timeline_data")
         end
     end
 
-    if self.timeline_menu then
-        UIManager:close(self.timeline_menu)
-        self.timeline_menu = nil
+    local header_ctx = {
+        title = self.loc:t("menu_timeline"),
+        order = data.order,
+        matrix = data.matrix,
+        chapters = data.chapter_titles,
+        matches = matches,
+        scroll_state = scroll_state,
+        scrollers = self._timeline_scrollers,
+        selected = self.timeline_filter,
+        empty_text = empty_text,
+        all_label = all_label,
+        show_map = show_map,
+        show_parent = nil,
+        on_back = function()
+            if self.timeline_view then UIManager:close(self.timeline_view) end
+        end,
+        on_toggle = function(name)
+            if name == nil then
+                self.timeline_filter = {}
+            else
+                local kept, removed = {}, false
+                for _, n in ipairs(self.timeline_filter) do
+                    if n == name then removed = true else kept[#kept + 1] = n end
+                end
+                if not removed then kept[#kept + 1] = name end
+                self.timeline_filter = kept
+            end
+            self:showTimeline()
+        end,
+    }
+
+    local sw = Screen:getWidth()
+    local pad = Screen:scaleBySize(10)
+    local ScrollableContainer = require("ui/widget/container/scrollablecontainer")
+    local text_w = sw - pad * 2 - ScrollableContainer:getScrollbarWidth()
+    local face = Font:getFace("cfont", 17)
+
+    -- Fixed row height lets the list size itself without laying out 365
+    -- paragraphs. Measuring it needs a throwaway TextBoxWidget, so memoize.
+    local line_h = _timelineLineHeight(face)
+    local text_h = line_h * 3           -- heading plus two lines of summary
+    local row_h = text_h + Screen:scaleBySize(14)
+
+    local function openRow(spec)
+        if spec and spec.ev then
+            self:showTimelineEventDetails(spec.ev, { source = "menu" })
+        end
     end
 
-    self.timeline_menu = self:newMenu("timeline_menu", { 
-        title = self.loc:t("menu_timeline"), 
-        item_table = items, 
-        is_borderless = true, 
-        width = Screen:getWidth(), 
-        height = Screen:getHeight(),
-        on_close_callback = function() 
-            if self.is_cancelled then return end
-            self:showFullXRayMenu() 
-        end,
-    })
-    UIManager:show(self.timeline_menu)
+    -- Both lists render the same kind of row. They differ only in their contents
+    -- and in whether a scrollbar takes width the rows would otherwise use.
+    local function rowList(specs, scrolls)
+        return XRayTimelineRowList:new{
+            specs = specs,
+            width = sw - (scrolls and ScrollableContainer:getScrollbarWidth() or 0),
+            text_width = text_w,
+            row_height = row_h,
+            text_height = text_h,
+            left_pad = pad,
+            face = face,
+            on_hold_row = openRow,
+        }
+    end
+
+    local rows = rowList(row_specs, true)
+
+    if self.timeline_view then
+        self._timeline_rebuilding = true
+        UIManager:close(self.timeline_view)
+        self._timeline_rebuilding = nil
+        self.timeline_view = nil
+    end
+    self.timeline_view = XRayTimelineView:new{
+        ui_instance = self,
+        header_ctx = header_ctx,
+        rows = rows,
+    }
+    UIManager:show(self.timeline_view)
 end
 
 function M:showTimelineEventDetails(ev, opts)

--- a/xray.koplugin/xray_ui.lua
+++ b/xray.koplugin/xray_ui.lua
@@ -3375,6 +3375,466 @@ function M:toggleXRayMode()
     })
 end
 
+-- How much of a large cast the header shows before it scrolls.
+-- These areas ignore pan, so the mouse wheel (which arrives as a pan) scrolls
+-- the chapter list instead. Swipe and the scrollbars still work here.
+local HEADER_IGNORED_GESTURES = {
+    "pan", "pan_release",          -- the mouse wheel arrives as a pan
+    "key_pg_back", "key_pg_fwd",   -- page keys belong to the chapter list
+}
+
+local STRIP_VISIBLE_ROWS = 3   -- character rows in the presence chart
+local BUTTON_VISIBLE_ROWS = 2  -- rows of filter buttons (3 buttons per row)
+
+-- Restore a scroll position across a rebuild.
+-- A filter change can leave less to scroll, so the saved offset is clamped to
+-- what the new content can actually reach.
+local function _restoreScroll(container, saved, content_h, viewport_h)
+    if not saved then return end
+    local max_offset = math.max(0, content_h - viewport_h)
+    container:setScrolledOffset(Geom:new{
+        x = 0,
+        y = math.max(0, math.min(saved.y or 0, max_offset)),
+    })
+end
+
+-- The timeline header: title bar, filter buttons, presence map. Embedded by
+-- XRayTimelineView; the chapter list below it is XRayTimelineRowList.
+local function _buildTimelineHeader(self, ctx)
+    local presence = require(plugin_path .. "xray_presencemap")
+    local xray_theme = require(plugin_path .. "xray_theme")
+    local HorizontalGroup = require("ui/widget/horizontalgroup")
+    local HorizontalSpan  = require("ui/widget/horizontalspan")
+    local ScrollableContainer = require("ui/widget/container/scrollablecontainer")
+    local TitleBar = require("ui/widget/titlebar")
+    local sw = Screen:getWidth()
+    local pad = Screen:scaleBySize(6)
+    local sbw = ScrollableContainer:getScrollbarWidth()
+    local components = { align = "left" }
+
+    -- The real TitleBar: same centering, close icon and RTL handling as every
+    -- other X-Ray screen, rather than hand-building the same thing.
+    table.insert(components, TitleBar:new{
+        width = sw,
+        title = ctx.title,
+        with_bottom_line = false,
+        close_callback = function() if ctx.on_back then ctx.on_back() end end,
+        show_parent = ctx.show_parent,
+    })
+
+    local all_label = ctx.all_label
+    local defs = { { label = all_label, name = nil } }
+    for _, name in ipairs(ctx.order) do
+        defs[#defs + 1] = { label = name, name = name }
+    end
+    local is_selected = {}
+    for _, name in ipairs(ctx.selected) do is_selected[name] = true end
+
+    -- Three per row fits most full names; four truncates to "Victor Frank". Past
+    -- BUTTON_VISIBLE_ROWS the group scrolls, so a large cast cannot crowd out
+    -- the chapters.
+    local per_row = 3
+    local btn_scrolls = math.ceil(#defs / per_row) > BUTTON_VISIBLE_ROWS
+    -- Wider inset than the rest of the header: labels are flush left inside
+    -- borderless buttons, so the first column would sit against the screen edge.
+    local btn_pad = Screen:scaleBySize(18)
+    local btn_w = math.floor((sw - btn_pad * 2 - (btn_scrolls and sbw or 0)) / per_row)
+    -- Rows stay left-aligned so buttons line up in a column. The block itself is
+    -- centered below.
+    local button_group = VerticalGroup:new{ align = "left" }
+    local row_items = nil
+    for i, def in ipairs(defs) do
+        if (i - 1) % per_row == 0 then
+            row_items = { align = "center" }
+            table.insert(button_group, HorizontalGroup:new(row_items))
+        end
+        local is_on = (def.name == nil) and #ctx.selected == 0 or is_selected[def.name] or false
+        -- A borderless Button with a filled/empty square, not CheckButton: the square
+        -- reads better at this density and Button truncates with a real ellipsis.
+        table.insert(row_items, Button:new{
+            text = (is_on and "\u{25A0} " or "\u{25A1} ") .. def.label,
+            width = btn_w,
+            max_width = btn_w,
+            align = "left",
+            bordersize = 0,
+            background = xray_theme.color_bg,
+            text_font_size = 14,
+            show_parent = ctx.show_parent,
+            callback = function() ctx.on_toggle(def.name) end,
+        })
+    end
+    local CenterContainer = require("ui/widget/container/centercontainer")
+    if btn_scrolls then
+        -- Full screen width, so this scrollbar lines up with the ones below it.
+        -- The buttons are centered inside the container instead.
+        local group_w = button_group:getSize().w
+        local inset = math.max(0, math.floor((sw - sbw - group_w) / 2))
+        local button_block = ScrollableContainer:new{
+            dimen = Geom:new{
+                w = sw,
+                h = math.floor(button_group:getSize().h * BUTTON_VISIBLE_ROWS / #button_group),
+            },
+            ignore_events = HEADER_IGNORED_GESTURES,
+            show_parent = ctx.show_parent,
+            HorizontalGroup:new{
+                align = "top",
+                HorizontalSpan:new{ width = inset },
+                button_group,
+            },
+        }
+        -- Tapping a character rebuilds the whole view, so without this the list
+        -- would jump back to the top and lose the button just tapped.
+        _restoreScroll(button_block, ctx.scroll_state.buttons,
+                       button_group:getSize().h, button_block.dimen.h)
+        ctx.scrollers.buttons = button_block
+        table.insert(components, button_block)
+    else
+        table.insert(components, CenterContainer:new{
+            dimen = Geom:new{ w = sw, h = button_group:getSize().h },
+            button_group,
+        })
+    end
+    table.insert(components, VerticalSpan:new{ width = pad })
+
+    local ncols = #ctx.chapters
+    if ncols > 0 and ctx.show_map then
+        local RenderImage = require("ui/renderimage")
+        local ImageWidget = require("ui/widget/imagewidget")
+
+        local shown_rows = #presence.shownNames(ctx.order, ctx.selected)
+        local strip_scrolls = shown_rows > STRIP_VISIBLE_ROWS
+        local name_w = math.floor(sw * 0.22)
+        local viewport_w = sw - pad * 2 - name_w - (strip_scrolls and sbw or 0)
+
+        -- One column per chapter while they stay at least min_col wide.
+        -- Past that, each column covers a span so the whole book still fits.
+        local min_col = Screen:scaleBySize(16)
+        local max_cols = math.max(1, math.floor(viewport_w / min_col))
+        local bucketed_matrix, match_cols, ranges
+        local columns = ctx.chapters
+        if ncols > max_cols then
+            bucketed_matrix, match_cols, ranges =
+                presence.bucketMatrix(ctx.matrix, ctx.matches, max_cols)
+            columns = ranges
+        else
+            match_cols = ctx.matches
+        end
+        ncols = #columns
+
+        local geom = {
+            name_width = name_w,
+            col_width = math.floor(viewport_w / ncols),
+            row_height = Screen:scaleBySize(20),
+            top_padding = Screen:scaleBySize(6),
+            marker = Screen:scaleBySize(9),
+            label_size = Screen:scaleBySize(9),
+        }
+
+        local names_svg, nw, nh = presence.buildStripNamesSVG(ctx.order, ctx.selected, geom)
+        local grid_svg, gw, gh = presence.buildStripGridSVG(
+            bucketed_matrix or ctx.matrix, ctx.order, columns, ctx.selected, geom, match_cols)
+
+        -- Rasterize each at exactly its own dimensions; a mismatch would send
+        -- renderimage.lua down its scaleBlitBuffer path and blur the result.
+        local ok_n, names_bb = pcall(RenderImage.renderImageData, RenderImage,
+            names_svg, #names_svg, false, nw, nh)
+        local ok_g, grid_bb = pcall(RenderImage.renderImageData, RenderImage,
+            grid_svg, #grid_svg, false, gw, gh)
+
+        if ok_n and names_bb and ok_g and grid_bb then
+            -- Columns always fit the viewport, so the grid never scrolls
+            -- sideways. Height is the constraint instead.
+            local strip = HorizontalGroup:new{
+                align = "top",
+                HorizontalSpan:new{ width = pad },
+                ImageWidget:new{ image = names_bb, image_disposable = true },
+                ImageWidget:new{ image = grid_bb, image_disposable = true },
+            }
+            if strip_scrolls then
+                -- Names and grid scroll together, so a row's marks never drift
+                -- away from its name.
+                local strip_block = ScrollableContainer:new{
+                    dimen = Geom:new{
+                        w = sw,
+                        h = presence.stripHeight(STRIP_VISIBLE_ROWS, geom),
+                    },
+                    ignore_events = HEADER_IGNORED_GESTURES,
+                    show_parent = ctx.show_parent,
+                    strip,
+                }
+                _restoreScroll(strip_block, ctx.scroll_state.strip,
+                               gh, strip_block.dimen.h)
+                ctx.scrollers.strip = strip_block
+                table.insert(components, strip_block)
+            else
+                table.insert(components, strip)
+            end
+            table.insert(components, VerticalSpan:new{ width = pad })
+        else
+            self:log("XRayPlugin: Timeline: strip render failed")
+        end
+    end
+
+    if ctx.empty_text then
+        table.insert(components, VerticalSpan:new{ width = pad * 4 })
+        table.insert(components, TextBoxWidget:new{
+            text = ctx.empty_text,
+            face = Font:getFace("cfont", 17),
+            width = sw - pad * 4,
+            alignment = "center",
+        })
+    else
+        table.insert(components, LineWidget:new{
+            dimen = Geom:new{ w = sw, h = (Size.line and Size.line.thick) or 2 },
+            background = xray_theme.color_border,
+        })
+    end
+
+    return FrameContainer:new{
+        bordersize = 0,
+        padding = 0,
+        background = xray_theme.color_bg,
+        VerticalGroup:new(components),
+    }
+end
+
+-- TextBoxWidget renders inline bold when the text opens with PTF_HEADER and the
+-- bold runs are wrapped in PTF_BOLD_START/END. xray_settings_card does the same.
+-- Using the frontend's own constants means an upstream change cannot silently
+-- drop the bold.
+local MARKUP_ON = TextBoxWidget.PTF_HEADER
+local BOLD_ON = TextBoxWidget.PTF_BOLD_START
+local BOLD_OFF = TextBoxWidget.PTF_BOLD_END
+
+-- Full-screen timeline: header on top, then the chapters as headed paragraphs
+-- (a Menu strips newlines, so it cannot put a summary beneath a heading).
+local XRayTimelineView = InputContainer:extend{
+    ui_instance = nil,
+    header_ctx = nil,   -- built in init, once there is a show_parent to give it
+    rows = nil,
+}
+
+function XRayTimelineView:init()
+    local sw, sh = Screen:getWidth(), Screen:getHeight()
+    self.dimen = Geom:new{ x = 0, y = 0, w = sw, h = sh }
+
+    local Device = require("device")
+    if Device.hasKeys and Device:hasKeys() then
+        self.key_events = { Close = { { Device.input.group.Back } } }
+    end
+    -- No swipe-to-dismiss: a swipe the chapter list cannot consume would fall
+    -- through and close the view mid-scroll. Use the close icon or Back key.
+
+    -- Built here, not by the caller, so buttons and scrollers get a real
+    -- show_parent; without one a scroller repaints via setDirty(nil).
+    local xray_theme = require(plugin_path .. "xray_theme")
+    self.header_ctx.show_parent = self
+    self.header = _buildTimelineHeader(self.ui_instance, self.header_ctx)
+
+    local ScrollableContainer = require("ui/widget/container/scrollablecontainer")
+    local header_h = self.header:getSize().h
+    local body_h = sh - header_h
+    if body_h < Screen:scaleBySize(60) then body_h = Screen:scaleBySize(60) end
+
+    local body = ScrollableContainer:new{
+        dimen = Geom:new{ w = sw, h = body_h },
+        show_parent = self,
+        self.rows,
+    }
+    -- UIManager crops repaints to one registered scrollable per screen, and only
+    -- the body is registered. Known consequence: a pan starting in the chapter
+    -- list that crosses into the header band can be claimed by the wrong container.
+    self.cropping_widget = body
+
+    self[1] = FrameContainer:new{
+        bordersize = 0,
+        padding = 0,
+        background = xray_theme.color_bg,
+        VerticalGroup:new{
+            align = "left",
+            self.header,
+            body,
+        },
+    }
+end
+
+function XRayTimelineView:onClose()
+    UIManager:close(self)
+    return true
+end
+
+function XRayTimelineView:onShow()
+    UIManager:setDirty(self, "ui")
+    return true
+end
+
+function XRayTimelineView:onCloseWidget()
+    local ui = self.ui_instance
+    if ui then
+        ui.timeline_view = nil
+        if not ui._timeline_rebuilding then
+            -- Filter state is per visit: reopening starts on All.
+            ui.timeline_filter = {}
+        end
+        -- Only a real close returns to the X-Ray menu. Every filter tap also
+        -- closes this view so showTimeline can rebuild it, and treating that as
+        -- a close would stack a fresh menu underneath each time.
+        if not ui.is_cancelled and not ui._timeline_rebuilding
+                and ui.showFullXRayMenu then
+            ui:showFullXRayMenu()
+        end
+    end
+    UIManager:setDirty(nil, "ui")
+end
+
+-- The chapter list, built one row at a time as rows come into view.
+--
+-- TextBoxWidget lays out in the constructor, so building every row up front
+-- cost 19MB and 84ms for 365 rows. Rows are a fixed height, so the list can
+-- report its size without laying anything out, and paintTo builds only the
+-- rows on screen.
+-- One chapter: bold heading, then the summary beneath, capped to a fixed height.
+local function _buildTimelineRowText(text_width, text_height, face, chapter, event)
+    local function esc(t)
+        -- The markup control chars must not appear in the content itself.
+        return (tostring(t or ""):gsub("[\xEF][\xBF][\xB1-\xB3]", ""))
+    end
+    local body = esc(event)
+    local text = MARKUP_ON .. BOLD_ON .. esc(chapter) .. BOLD_OFF
+    if #body > 0 then text = text .. "\n" .. body end
+    return TextBoxWidget:new{
+        text = text,
+        face = face,
+        width = text_width,
+        height = text_height,
+        height_overflow_show_ellipsis = true,
+        alignment = "left",
+    }
+end
+
+-- Line height for a face, measured once. Building a TextBoxWidget is the only
+-- way to ask, and too slow to repeat on every rebuild.
+local _line_height_cache = {}
+local function _timelineLineHeight(face)
+    local cached = _line_height_cache[face]
+    if not cached then
+        local probe = TextBoxWidget:new{ text = "X", face = face, width = 200 }
+        cached = probe:getLineHeight()
+        probe:free()
+        _line_height_cache[face] = cached
+    end
+    return cached
+end
+
+-- Rows kept either side of the viewport before eviction.
+local KEEP_MARGIN = 20
+
+local XRayTimelineRowList = InputContainer:extend{
+    specs = nil,        -- { { chapter, event, ev }, ... }
+    width = nil,
+    text_width = nil,
+    row_height = nil,
+    text_height = nil,
+    left_pad = 0,
+    face = nil,
+    on_hold_row = nil,
+}
+
+function XRayTimelineRowList:init()
+    self._cache = {}
+    self.dimen = Geom:new{ x = 0, y = 0, w = self.width, h = self:_totalHeight() }
+    -- Tap opens the chapter's details; hold does the same.
+    self.ges_events = {
+        Tap = {
+            GestureRange:new{ ges = "tap", range = function() return self.dimen end },
+        },
+        Hold = {
+            GestureRange:new{ ges = "hold", range = function() return self.dimen end },
+        },
+    }
+end
+
+function XRayTimelineRowList:_totalHeight()
+    return #self.specs * self.row_height
+end
+
+function XRayTimelineRowList:getSize()
+    return Geom:new{ w = self.width, h = self:_totalHeight() }
+end
+
+function XRayTimelineRowList:_row(i)
+    local widget = self._cache[i]
+    if not widget then
+        local spec = self.specs[i]
+        widget = _buildTimelineRowText(self.text_width, self.text_height,
+                                       self.face, spec.chapter, spec.event)
+        self._cache[i] = widget
+    end
+    return widget
+end
+
+function XRayTimelineRowList:paintTo(bb, x, y)
+    self.dimen.x, self.dimen.y = x, y
+    local n = #self.specs
+    if n == 0 then return end
+
+    -- Rows intersecting the buffer. y is already shifted by the scroll offset.
+    local first = math.max(1, math.floor(-y / self.row_height) + 1)
+    local last = math.min(n, math.ceil((bb:getHeight() - y) / self.row_height))
+
+    local gap = math.floor((self.row_height - self.text_height) / 2)
+    for i = first, last do
+        local top = y + (i - 1) * self.row_height
+        self:_row(i):paintTo(bb, x + self.left_pad, top + gap)
+        if i < n then
+            bb:paintRect(x, top + self.row_height - 1, self.width, 1,
+                         Blitbuffer.COLOR_LIGHT_GRAY)
+        end
+    end
+
+    -- Drop rows well outside the viewport, or scrolling end to end would cache
+    -- every row and defeat the point of the lazy list.
+    local keep_from, keep_to = first - KEEP_MARGIN, last + KEEP_MARGIN
+    for i, widget in pairs(self._cache) do
+        if i < keep_from or i > keep_to then
+            if widget.free then widget:free() end
+            self._cache[i] = nil
+        end
+    end
+end
+
+function XRayTimelineRowList:_openRowAt(ges)
+    if not (ges and ges.pos and self.on_hold_row) then return false end
+    local offset = ges.pos.y - self.dimen.y
+    local i = math.floor(offset / self.row_height) + 1
+    if i >= 1 and i <= #self.specs then
+        self.on_hold_row(self.specs[i])
+        return true
+    end
+    return false
+end
+
+function XRayTimelineRowList:onTap(_, ges)
+    return self:_openRowAt(ges)
+end
+
+function XRayTimelineRowList:onHold(_, ges)
+    return self:_openRowAt(ges)
+end
+
+function XRayTimelineRowList:onCloseWidget()
+    for _, w in pairs(self._cache or {}) do
+        if w.free then w:free() end
+    end
+    self._cache = {}
+end
+
+
+-- None of this depends on which characters are filtered, and some of it is very
+-- expensive. assignTimelinePages runs full-document findText scans for chapter
+-- titles that miss the TOC, which would cost seconds on every filter tap.
+-- Identity alone is not enough: merges and "fetch more characters" mutate
+-- self.characters in place, so the name list is compared as well.
 function M:showTimeline()
     if not self.timeline or #self.timeline == 0 then UIManager:show(InfoMessage:new{ text = self.loc:t("no_timeline_data"), timeout = 3 }); return end
     local utils = require(plugin_path .. "xray_utils")

--- a/xray.koplugin/xray_ui.lua
+++ b/xray.koplugin/xray_ui.lua
@@ -3385,6 +3385,7 @@ local HEADER_IGNORED_GESTURES = {
 
 local STRIP_VISIBLE_ROWS = 3   -- character rows in the presence chart
 local BUTTON_VISIBLE_ROWS = 2  -- rows of filter buttons (3 buttons per row)
+local PRIOR_VISIBLE_ROWS = 2   -- earlier books shown before the recap block scrolls
 
 -- Restore a scroll position across a rebuild.
 -- A filter change can leave less to scroll, so the saved offset is clamped to
@@ -3573,6 +3574,42 @@ local function _buildTimelineHeader(self, ctx)
         else
             self:log("XRayPlugin: Timeline: strip render failed")
         end
+    end
+
+    -- Earlier books in the series, in a scroller of their own so a long series
+    -- cannot push this book's chapters off the screen.
+    -- The caller builds the list only when the block is open, so a list here
+    -- means it is open.
+    if ctx.prior_specs then
+        table.insert(components, HorizontalGroup:new{
+            align = "center",
+            HorizontalSpan:new{ width = pad },
+            Button:new{
+                text = (ctx.prior_list and "▼ " or "► ") .. ctx.prior_label,
+                width = sw - pad * 2,
+                max_width = sw - pad * 2,
+                align = "left",
+                bordersize = 0,
+                background = xray_theme.color_bg,
+                text_font_size = 14,
+                show_parent = ctx.show_parent,
+                callback = ctx.on_prior_toggle,
+            },
+        })
+        if ctx.prior_list then
+            local content_h = ctx.prior_list:getSize().h
+            local prior_block = ScrollableContainer:new{
+                dimen = Geom:new{ w = sw, h = ctx.prior_view_height },
+                ignore_events = HEADER_IGNORED_GESTURES,
+                show_parent = ctx.show_parent,
+                ctx.prior_list,
+            }
+            _restoreScroll(prior_block, ctx.scroll_state.prior,
+                           content_h, ctx.prior_view_height)
+            ctx.scrollers.prior = prior_block
+            table.insert(components, prior_block)
+        end
+        table.insert(components, VerticalSpan:new{ width = pad })
     end
 
     if ctx.empty_text then
@@ -3860,10 +3897,13 @@ local function _timelineData(self)
     self:sortTimelineByTOC(self.timeline)
 
     -- Matrix rows line up with current-book events only, in the same order, so
-    -- index i means the same in both.
-    local events, chapter_titles = {}, {}
+    -- index i means the same in both. Prior-book entries belong to no chapter
+    -- here, so they are set aside for the recap block rather than dropped.
+    local events, chapter_titles, prior_events = {}, {}, {}
     for _, ev in ipairs(self.timeline) do
-        if ev.source ~= "series_prior" then
+        if ev.source == "series_prior" then
+            prior_events[#prior_events + 1] = ev
+        else
             events[#events + 1] = ev
             chapter_titles[#chapter_titles + 1] = ev.chapter or ""
         end
@@ -3877,11 +3917,30 @@ local function _timelineData(self)
         signature = signature,
         events = events,
         chapter_titles = chapter_titles,
+        prior_events = prior_events,
         matrix = matrix,
         order = presence.coverageOrder(matrix, characters),
     }
     self._timeline_cache = cache
     return cache
+end
+
+-- One row per earlier book in the series, or nil when the block is hidden.
+--
+-- A character filter hides them: prior events are not in the presence matrix,
+-- so they can never match. Listing them anyway would suggest they did.
+function M:timelinePriorSpecs(prior_events, selected)
+    if not prior_events or #prior_events == 0 then return nil end
+    if selected and #selected > 0 then return nil end
+    local specs = {}
+    for _, ev in ipairs(prior_events) do
+        -- A recap is a whole book's events joined with blank lines, which would
+        -- waste one of the row's two preview lines. Only this copy is flattened;
+        -- the details popup reads ev itself.
+        local preview = (ev.event or ""):gsub("%s+", " "):match("^ *(.-) *$")
+        specs[#specs + 1] = { chapter = ev.chapter or "", event = preview, ev = ev }
+    end
+    return specs
 end
 
 -- Whether the timeline shows its presence map. Unset means on.
@@ -3899,6 +3958,11 @@ function M:showTimeline()
     self.timeline_filter = self.timeline_filter or {}
     local filtering = #self.timeline_filter > 0
 
+    -- Closed on first open, so the chapter list stays visible.
+    if self.series_prior_timeline_collapsed == nil then
+        self.series_prior_timeline_collapsed = true
+    end
+    local prior_specs = self:timelinePriorSpecs(data.prior_events, self.timeline_filter)
 
     -- The header is rebuilt on every filter tap, so scroll positions are carried
     -- across. A position is kept even when its scroller disappears: filtering to
@@ -3929,9 +3993,9 @@ function M:showTimeline()
         if filtering then
             empty_text = self.loc:t("timeline_no_shared_chapters",
                 table.concat(self.timeline_filter, " \u{00B7} "), all_label)
-        else
-            -- Not an empty timeline (caught above) but nothing for this book:
-            -- everything held is from earlier books in a series.
+        elseif not prior_specs then
+            -- Not an empty timeline (caught above) but nothing for this book.
+            -- If prior recaps exist they are the content, so say nothing.
             empty_text = self.loc:t("no_timeline_data")
         end
     end
@@ -3948,6 +4012,12 @@ function M:showTimeline()
         empty_text = empty_text,
         all_label = all_label,
         show_map = show_map,
+        prior_specs = prior_specs,
+        prior_label = self.loc:t("series_prior_books_header") or "── Prior Books ──",
+        on_prior_toggle = function()
+            self.series_prior_timeline_collapsed = not self.series_prior_timeline_collapsed
+            self:showTimeline()
+        end,
         show_parent = nil,
         on_back = function()
             if self.timeline_view then UIManager:close(self.timeline_view) end
@@ -4001,6 +4071,11 @@ function M:showTimeline()
     end
 
     local rows = rowList(row_specs, true)
+
+    if prior_specs and not self.series_prior_timeline_collapsed then
+        header_ctx.prior_list = rowList(prior_specs, #prior_specs > PRIOR_VISIBLE_ROWS)
+        header_ctx.prior_view_height = row_h * math.min(#prior_specs, PRIOR_VISIBLE_ROWS)
+    end
 
     if self.timeline_view then
         self._timeline_rebuilding = true

--- a/xray.koplugin/xray_ui.lua
+++ b/xray.koplugin/xray_ui.lua
@@ -2843,6 +2843,18 @@ function M:showAbout()
     UIManager:show(about_dlg)
 end
 
+-- Read a boolean setting, falling back to default when it is unset.
+--
+-- Menus reach this from checked_func while the plugin may still be starting up.
+-- touchmenu.lua calls checked_func without a pcall, so a nil ai_helper there
+-- aborts the whole submenu and every checkmark in it disappears.
+function M:settingEnabled(key, default)
+    local settings = self.ai_helper and self.ai_helper.settings
+    local value = settings and settings[key]
+    if value == nil then return default == true end
+    return value ~= false
+end
+
 function M:clearCache()
     if not self.cache_manager then self.cache_manager = require(plugin_path .. "xray_cachemanager"):new() end
     if self.ui and self.ui.document and self.ui.document.file then


### PR DESCRIPTION
Reading books with multiple characters, I thought it may be useful to see where each character goes in their recap, as well as improving the timeline UI. It was a `Menu` with one line per event, and now it becomes a scrolling view with an optional
character presence map above it, a sort toggle, and jump-to-end controls.

Each row shows the chapter heading and the first two lines of its summary, so you can
find a chapter without opening every entry. Tap or hold to open the full event.

The presence map is one row per character, one column per chapter, marked wherever that
character is named in the chapter title or summary. Characters are ordered by how many
chapters mention them; ties break by first appearance then name, so the order is stable
across rebuilds. It can be switched off in settings.

Tapping a character filters the list to chapters naming them. Tapping two filters to the
chapters they share, shading those columns and joining the rows with a line, which is how
you find where two characters meet.

Characters in fewer than two chapters are dropped as walk-ons, though anyone the AI
marked a protagonist is kept regardless. That minimum is ignored when it would leave
fewer than three rows: early in a book almost everyone appears once, and I figure an empty map is
worse than a crowded one.

The sort toggle reads `↑ Oldest first` or `↓ Newest first`, naming the current state
rather than the action so the arrow and the words agree. The map does not flip with it,
because it answers where in the book something happens, and that has one direction
however the list is stacked.

Two chevrons jump to the first and last row. Under a filter the list holds only matching
chapters, so those are the first and last match.

Series recaps from earlier books get a collapsible block above the list rather than being
mixed into this book's chapters. A character filter hides it, since prior-book events are
not in the matrix and can never match.

## Performance

Two things here are expensive: working out which page a chapter starts on, and matching
every character name against every chapter. The design keeps both off the interaction
path.

`assignTimelinePages` falls back to full-document `findText` scans for chapter titles the
TOC misses, costing seconds on a long book. It sits behind a cache keyed on the timeline
and character table identities plus a signature of the characters, so filtering, sorting
and jumping reuse one result, and matching runs at cache-build time rather than on a tap.
Identity alone would be unsafe, since merges and "fetch more characters" mutate the list
in place, so the signature covers name, aliases and role, each length-prefixed to stop a
name containing the separator forging a field boundary.

Sort direction is kept out of that key on purpose: reversing changes nothing the cache
holds, so including it would discard the page scan on every toggle. It reverses a copy,
because reversing the cached list in place would flip it again on the next redraw.

The list does not build rows it is not showing. `TextBoxWidget` lays out in its
constructor, and building all 365 rows of a long book up front measured 19MB and 84ms.
Fixed row height lets the list report its size without laying anything out, and `paintTo`
builds only on-screen rows, caching each after the first. The line height that depends on
is memoised per font face, since measuring costs a throwaway widget.

Matching uses plain substring search, not Lua patterns, so names with metacharacters need
no escaping, and the word-boundary check applies only where the needle's own edge is a
word character, keeping a name ending in `)` matchable. Each character stops at its first
hit, and needle lists are deduplicated so an alias repeating the name or surname costs no
second pass. Coverage and first appearance are accumulated in one walk over the matrix
rather than a rescan per character.

Where one column per chapter would fall below a minimum width, chapters collapse into
spans so the strip fits and the SVG stays small. Crossings are still computed per chapter
and passed in: two characters in different chapters of one span have not met, and
deriving crossings from a bucketed matrix would claim they had. Both SVGs are rasterised
at their exact dimensions so `renderimage` avoids its `scaleBlitBuffer` path.

Jumping moves the scroll offset via `scrollToRatio`, which also updates the scrollbar;
nothing is rebuilt. The filter block, the map and the Prior Books list each keep their
scroll position across rebuilds, so tapping a filter does not jog them back to the top.

## Layout and tests

Matching and layout live in `xray_presencemap.lua`, which has no KOReader dependencies,
so its spec runs outside KOReader and the geometry both renderers and UI need is exported
rather than duplicated. The suite is at 398 specs.

## Screenshots
<img width="1278" height="1390" alt="image" src="https://github.com/user-attachments/assets/98ab3f75-db70-4ada-b1c9-34d9bfc08667" />

<img width="1280" height="1391" alt="image" src="https://github.com/user-attachments/assets/fc2f9949-1f1f-46f9-812b-9ada9aed8412" />

<img width="1274" height="1391" alt="image" src="https://github.com/user-attachments/assets/54b2db59-1b2e-40ae-b67c-c3de04acec08" />

I also went ahead and folded in translations for the UI as well since I'm here. Let me know what you think!


